### PR TITLE
Make HDFSWalker debug method accept Consumer<String>

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalker.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalker.java
@@ -1,12 +1,12 @@
 package org.openstreetmap.atlas.generator.tools.streaming.resource;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -98,12 +98,12 @@ public final class HDFSWalker
         }
     }
 
-    public static Function<FileStatus, FileStatus> debug(final PrintStream stream)
+    public static Function<FileStatus, FileStatus> debug(final Consumer<String> printer)
     {
         return status ->
         {
             final char type = status.isSymlink() ? 'S' : status.isDirectory() ? 'D' : 'F';
-            stream.printf("[%c] %s\n", type, status.getPath());
+            printer.accept(String.format("[%c] %s", type, status.getPath()));
             return status;
         };
     }

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSCommand.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSCommand.java
@@ -11,6 +11,8 @@ import org.openstreetmap.atlas.streaming.NotifyingIOUtils.IOProgressListener;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.streaming.resource.StreamOfResourceStreams;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Sample program showing how to use the HDFSWalker utility class
@@ -61,6 +63,8 @@ public class HDFSCommand extends HDFSArgumentsCommand
         }
     }
 
+    private static final Logger logger = LoggerFactory.getLogger(HDFSCommand.class);
+
     public static void main(final String... args)
     {
         new HDFSCommand().runWithoutQuitting(args);
@@ -70,10 +74,11 @@ public class HDFSCommand extends HDFSArgumentsCommand
     protected int onRun(final CommandMap command)
     {
         super.onRun(command);
-        HDFSWalker.walk(getRoot()).map(HDFSWalker.debug(System.out)).forEach(status ->
-        {
-            // Do something with the HDFS FileStatus
-        });
+        HDFSWalker.walk(getRoot()).map(HDFSWalker.debug(path -> logger.info("{}", path)))
+                .forEach(status ->
+                {
+                    // Do something with the HDFS FileStatus
+                });
 
         final AtomicLong iosize = new AtomicLong();
         try (InputStream stream = new StreamOfResourceStreams(HDFSWalker.walk(getRoot())

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
@@ -1,0 +1,93 @@
+package org.openstreetmap.atlas.generator.tools.streaming.resource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.utilities.tuples.Tuple;
+
+/**
+ * Tests for {@link HDFSWalker}.
+ *
+ * @author mkalender
+ */
+public class HDFSWalkerTest
+{
+    private static Tuple<List<FileStatus>, List<String>> test(final File directory)
+    {
+        final List<FileStatus> fileStatusList = new ArrayList<>();
+        final List<String> debugStrings = new ArrayList<>();
+        HDFSWalker.walk(new Path(directory.getPath())).map(HDFSWalker.debug(debugStrings::add))
+                .forEach(status ->
+                {
+                    fileStatusList.add(status);
+                });
+        return Tuple.createTuple(fileStatusList, debugStrings);
+    }
+
+    @Test
+    public void testDirectoryWithAFile()
+    {
+        final File directory = File.temporaryFolder();
+        directory.child("test.tmp").writeAndClose("test file");
+        final Tuple<List<FileStatus>, List<String>> results = test(directory);
+
+        // Verify file statuses
+        Assert.assertFalse(results.getFirst().isEmpty());
+        Assert.assertEquals(1, results.getFirst().size());
+
+        // Verify debug strings
+        Assert.assertFalse(results.getSecond().isEmpty());
+        Assert.assertEquals(1, results.getSecond().size());
+        Assert.assertEquals(
+                String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp"),
+                results.getSecond().get(0));
+
+        // Clean up
+        directory.deleteRecursively();
+    }
+
+    @Test
+    public void testDirectoryWithAFileInsideAChildDirectory()
+    {
+        final File directory = File.temporaryFolder();
+        directory.child("test.tmp").writeAndClose("test file");
+        final File childDirectory = directory.child("child-directory");
+        Assert.assertTrue(childDirectory.mkdirs());
+        childDirectory.child("file-in-child-directory.tmp").writeAndClose("test child file");
+
+        // Verify file statuses
+        final Tuple<List<FileStatus>, List<String>> results = test(directory);
+        Assert.assertFalse(results.getFirst().isEmpty());
+        Assert.assertEquals(3, results.getFirst().size());
+
+        // Verify debug strings
+        Assert.assertFalse(results.getSecond().isEmpty());
+        Assert.assertEquals(3, results.getSecond().size());
+        Assert.assertTrue(results.getSecond().contains(
+                String.format("[D] file:%s/%s", directory.getAbsolutePath(), "child-directory")));
+        Assert.assertTrue(results.getSecond().contains(String.format("[F] file:%s/%s",
+                childDirectory.getAbsolutePath(), "file-in-child-directory.tmp")));
+        Assert.assertTrue(results.getSecond().contains(
+                String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp")));
+
+        // Clean up
+        directory.deleteRecursively();
+    }
+
+    @Test
+    public void testEmptyDirectory()
+    {
+        final File emptyDirectory = File.temporaryFolder();
+        final Tuple<List<FileStatus>, List<String>> results = test(emptyDirectory);
+
+        // Verify status and debug strings are empty
+        Assert.assertTrue(results.getFirst().isEmpty());
+        Assert.assertTrue(results.getSecond().isEmpty());
+        emptyDirectory.deleteRecursively();
+    }
+}


### PR DESCRIPTION
This PR updates `HDFSWalker`'s `debug` to accept `Consumer<String>` rather than `PrintStream`. `Consumer<String>` is more generic and clients can come up with their own way to consume paths. As an example, I change `FileSystemHelper` to log file path as informational message.