### PR TITLE
Added a verification that missing shards are actually missing

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.0.5-SNAPSHOT',
+    atlas: '5.0.5',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.0.0',
+    atlas: '5.0.5-SNAPSHOT',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
@@ -1,11 +1,11 @@
 package org.openstreetmap.atlas.generator.sharding;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.openstreetmap.atlas.exception.CoreException;
+import org.apache.http.HttpHost;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Rectangle;
@@ -15,17 +15,20 @@ import org.openstreetmap.atlas.geography.clipping.Clip.ClipType;
 import org.openstreetmap.atlas.geography.sharding.CountryShard;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
-import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.streaming.writers.SafeBufferedWriter;
 import org.openstreetmap.atlas.tags.Taggable;
 import org.openstreetmap.atlas.tags.filters.ConfiguredTaggableFilter;
-import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
 import org.openstreetmap.atlas.utilities.runtime.Command;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
 import org.openstreetmap.atlas.utilities.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.index.strtree.STRtree;
 
 /**
  * Checks intersection of country boundary and shards to validate missing shards.
@@ -35,6 +38,7 @@ import org.slf4j.LoggerFactory;
 public class AtlasMissingShardVerifier extends Command
 {
     private static final Logger logger = LoggerFactory.getLogger(AtlasMissingShardVerifier.class);
+    private static final String FILTER_CONFIG = "/org/openstreetmap/atlas/geography/atlas/pbf/osm-pbf-way.json";
 
     private static final Switch<CountryBoundaryMap> BOUNDARIES = new Switch<>("boundaries",
             "The country boundaries.", value -> initializeCountryBoundaryMap(value),
@@ -45,10 +49,36 @@ public class AtlasMissingShardVerifier extends Command
             "Country shards that are listed as missing", File::new, Optionality.REQUIRED);
     private static final Switch<String> OVERPASS_SERVER = new Switch<>("server",
             "The overpass server to query from", value -> value, Optionality.OPTIONAL);
+    private static final Switch<StringList> PROXY_SETTINGS = new Switch<>("proxySettings",
+            "Proxy host and port number, split by comma", value -> StringList.split(value, ","),
+            Optionality.OPTIONAL);
 
     public static void main(final String[] args)
     {
         new AtlasMissingShardVerifier().run(args);
+    }
+
+    private static String createMasterQuery(final CountryBoundaryMap boundaries,
+            final Set<CountryShard> missingCountryShards)
+    {
+        // Build Overpass query that downloads all the nodes and ways needed
+        final StringBuilder masterQuery = new StringBuilder("(");
+        for (final CountryShard countryShard : missingCountryShards)
+        {
+            final Clip clip = intersectionClip(countryShard, boundaries);
+            final Rectangle clipBounds = clip.getClipMultiPolygon().bounds();
+            masterQuery.append(OverpassClient.buildCompactQuery("node", clipBounds));
+        }
+        masterQuery.append(");out body;");
+        return masterQuery.toString();
+    }
+
+    private static HttpHost createProxy(final StringList proxySettings) throws NumberFormatException
+    {
+        final String proxyHost = proxySettings.get(0);
+        final int proxyPort = Integer.parseInt(proxySettings.get(1));
+        logger.info("Proxy Host: " + proxyHost + " Port: " + proxyPort);
+        return new HttpHost(proxyHost, proxyPort);
     }
 
     private static CountryBoundaryMap initializeCountryBoundaryMap(final String value)
@@ -60,49 +90,112 @@ public class AtlasMissingShardVerifier extends Command
         return result;
     }
 
+    private static STRtree initializeNodeTree(final List<OverpassOsmNode> nodes)
+    {
+        final STRtree nodeTree = new STRtree();
+        nodes.forEach(node ->
+        {
+            nodeTree.insert(new Envelope(new Coordinate(Double.parseDouble(node.getLongitude()),
+                    Double.parseDouble(node.getLatitude()))), node);
+        });
+        logger.info("Imported " + nodeTree.size() + " nodes to tree");
+        return nodeTree;
+    }
+
+    private static STRtree initializeWayTree(final List<OverpassOsmNode> nodes,
+            final List<OverpassOsmWay> ways)
+    {
+        final STRtree wayTree = new STRtree();
+        final HashMap<String, OverpassOsmNode> nodeIds = new HashMap<>();
+        nodes.forEach(node -> nodeIds.put(node.getIdentifier(), node));
+        ways.forEach(way ->
+        {
+            Envelope startPoint = new Envelope();
+            for (final String nodeId : way.getNodeIdentifiers())
+            {
+                if (startPoint == null && nodeIds.containsKey(nodeId))
+                {
+                    startPoint = new Envelope(
+                            new Coordinate(Double.parseDouble(nodeIds.get(nodeId).getLongitude()),
+                                    Double.parseDouble(nodeIds.get(nodeId).getLatitude())));
+                }
+                else if (nodeIds.containsKey(nodeId))
+                {
+                    final Coordinate nextPoint = new Coordinate(
+                            Double.parseDouble(nodeIds.get(nodeId).getLongitude()),
+                            Double.parseDouble(nodeIds.get(nodeId).getLatitude()));
+                    startPoint.expandToInclude(nextPoint);
+                }
+            }
+            wayTree.insert(startPoint, way);
+        });
+        logger.info("Imported " + wayTree.size() + " ways to tree");
+        return wayTree;
+    }
+
+    private static Clip intersectionClip(final CountryShard countryShard,
+            final CountryBoundaryMap boundaries)
+    {
+        return new Clip(ClipType.AND, countryShard.bounds(),
+                boundaries.countryBoundary(countryShard.getCountry()).get(0).getBoundary());
+    }
+
+    private static Set<CountryShard> removeShardsWithZeroIntersection(
+            final Set<CountryShard> missingCountryShards, final CountryBoundaryMap boundaries)
+    {
+        missingCountryShards.removeIf(countryShard ->
+        {
+            final Clip clip = intersectionClip(countryShard, boundaries);
+            return clip.getClipMultiPolygon().surface().asDm7Squared() == 0;
+        });
+        return missingCountryShards;
+    }
+
     public int verifier(final CountryBoundaryMap boundaries,
-            final Set<CountryShard> missingCountryShards, final File output, final String server)
+            final Set<CountryShard> missingCountryShardsUntrimmed, final File output,
+            final String server, final HttpHost proxy)
     {
         int returnCode = 0;
+        final Set<CountryShard> missingCountryShards = removeShardsWithZeroIntersection(
+                missingCountryShardsUntrimmed, boundaries);
+        final String masterQuery = createMasterQuery(boundaries, missingCountryShards);
+        final OverpassClient client = new OverpassClient(server, proxy);
+        final ConfiguredTaggableFilter filter = new ConfiguredTaggableFilter(
+                new StandardConfiguration(new InputStreamResource(
+                        AtlasMissingShardVerifier.class.getResourceAsStream(FILTER_CONFIG))));
         try (SafeBufferedWriter writer = output.writer())
         {
-            final OverpassClient client = new OverpassClient(server);
-            final List<CountryShard> verifiedMissingShards = new ArrayList<>();
+            final List<OverpassOsmNode> nodes = client.nodesFromQuery(masterQuery);
+            final List<OverpassOsmWay> ways = client.waysFromQuery(masterQuery);
+            final STRtree nodeTree = initializeNodeTree(nodes);
+            final STRtree wayTree = initializeWayTree(nodes, ways);
             for (final CountryShard countryShard : missingCountryShards)
             {
-                logger.info(countryShard.toString());
-                final Clip clip = new Clip(ClipType.AND, countryShard.bounds(),
-                        boundaries.countryBoundary(countryShard.getCountry()).get(0).getBoundary());
-                if (clip.getClipMultiPolygon().surface().asDm7Squared() == 0)
-                {
-                    continue;
-                }
+                final Clip clip = intersectionClip(countryShard, boundaries);
                 final MultiPolygon clipMulti = clip.getClipMultiPolygon();
                 final Rectangle clipBounds = clipMulti.bounds();
-                // Take in list of all nodes, then filter out nodes that aren't ingested into
-                // Atlas
-                final Time nodeStart = Time.now();
-                final List<OverpassOsmNode> nodeList = client
-                        .nodesFromQuery(OverpassClient.buildQuery("node", clipBounds));
-                logger.info("Node query finished in: " + nodeStart.elapsedSince());
-                final Time wayStart = Time.now();
-                final List<OverpassOsmWay> ways = client
-                        .waysFromQuery(OverpassClient.buildQuery("way", clipBounds));
-                logger.info("Way query finished in: " + wayStart.elapsedSince());
-                final Resource resource = new InputStreamResource(
-                        AtlasMissingShardVerifier.class.getResourceAsStream(
-                                "/org/openstreetmap/atlas/geography/atlas/pbf/osm-pbf-way.json"));
-                final Configuration configuration = new StandardConfiguration(resource);
-                final ConfiguredTaggableFilter filter = new ConfiguredTaggableFilter(configuration);
-                for (final OverpassOsmWay way : ways)
+                @SuppressWarnings("unchecked")
+                final List<OverpassOsmNode> nodeList = nodeTree.query(clipBounds.asEnvelope());
+                // Prune extra nodes returned by STRtree that might not actually be contained within
+                // clipBounds
+                nodeList.removeIf(node ->
                 {
-                    final Taggable taggableWay = Taggable.with(way.getTags());
-                    if (!filter.test(taggableWay))
-                    {
-                        nodeList.removeIf(
-                                node -> way.getNodeIdentifiers().contains(node.getIdentifier()));
-                    }
-                }
+                    return !clipBounds.fullyGeometricallyEncloses(
+                            Location.forString(node.getLatitude() + "," + node.getLongitude()));
+                });
+                @SuppressWarnings("unchecked")
+                final List<OverpassOsmWay> wayList = wayTree.query(clipBounds.asEnvelope());
+                // Filter out ways that aren't ingested into atlas
+                wayList.stream().filter(way -> !filter.test(Taggable.with(way.getTags())))
+                        .forEach(way ->
+                        {
+                            nodeList.removeIf(node -> way.getNodeIdentifiers()
+                                    .contains(node.getIdentifier()));
+                        });
+                // Loop over the remaining nodes, which now consist of only nodes that should be
+                // ingested into atlas
+                // If a node is found within the intersection of the country boundary and shard
+                // bounds then the shard should have been built, so break and list the shard
                 for (final OverpassOsmNode node : nodeList)
                 {
                     final Location nodeLocation = Location
@@ -113,26 +206,23 @@ public class AtlasMissingShardVerifier extends Command
                         writer.writeLine(countryShard.toString());
                         writer.writeLine(
                                 "Boundary/Shard intersection zone: " + clipMulti.toString());
-                        writer.writeLine("Id of relevant node geometry: " + node.getIdentifier());
+                        writer.writeLine("Id of node that should have been imported: "
+                                + node.getIdentifier());
                         writer.writeLine("Node Location: " + nodeLocation.toString() + "\n");
-                        verifiedMissingShards.add(countryShard);
+                        logger.info(countryShard.toString() + " is missing!");
                         break;
                     }
                 }
             }
-            if (verifiedMissingShards.isEmpty())
-            {
-                logger.info("No shards are missing!");
-            }
-            else
-            {
-                verifiedMissingShards
-                        .forEach(value -> logger.info(value.toString() + " is missing!"));
-            }
         }
         catch (final Exception e)
         {
-            throw new CoreException("Could not match shards to boundaries", e);
+            logger.error("Error!", e);
+            return -1;
+        }
+        if (returnCode == 0)
+        {
+            logger.info("No shards are missing!");
         }
         return returnCode;
     }
@@ -143,14 +233,33 @@ public class AtlasMissingShardVerifier extends Command
         final CountryBoundaryMap boundaries = (CountryBoundaryMap) command.get(BOUNDARIES);
         final File missingShardFile = (File) command.get(MISSING_SHARDS);
         final File output = (File) command.get(OUTPUT);
+        if (!missingShardFile.exists() || missingShardFile.all().equals(""))
+        {
+            logger.info("No missing shards to check!");
+            return 0;
+        }
         final Set<CountryShard> missingCountryShards = missingShardFile.linesList().stream()
                 .map(CountryShard::forName).collect(Collectors.toSet());
         final String server = (String) command.get(OVERPASS_SERVER);
+        final StringList proxySettings = (StringList) command.get(PROXY_SETTINGS);
+        HttpHost proxy = null;
+        if (proxySettings != null)
+        {
+            try
+            {
+                proxy = createProxy(proxySettings);
+            }
+            catch (final Exception e)
+            {
+                logger.error("Proxy settings not correctly set", e);
+                return -1;
+            }
+        }
         final Time fullStart = Time.now();
         final int returnCode;
         try
         {
-            returnCode = verifier(boundaries, missingCountryShards, output, server);
+            returnCode = verifier(boundaries, missingCountryShards, output, server, proxy);
         }
         catch (final Exception e)
         {
@@ -163,6 +272,7 @@ public class AtlasMissingShardVerifier extends Command
     @Override
     protected SwitchList switches()
     {
-        return new SwitchList().with(BOUNDARIES, OUTPUT, MISSING_SHARDS, OVERPASS_SERVER);
+        return new SwitchList().with(BOUNDARIES, OUTPUT, MISSING_SHARDS, OVERPASS_SERVER,
+                PROXY_SETTINGS);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
@@ -1,0 +1,153 @@
+package org.openstreetmap.atlas.generator.sharding;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.MultiPolygon;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
+import org.openstreetmap.atlas.geography.clipping.Clip;
+import org.openstreetmap.atlas.geography.clipping.Clip.ClipType;
+import org.openstreetmap.atlas.geography.sharding.CountryShard;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.streaming.writers.SafeBufferedWriter;
+import org.openstreetmap.atlas.tags.Taggable;
+import org.openstreetmap.atlas.tags.filters.ConfiguredTaggableFilter;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
+import org.openstreetmap.atlas.utilities.runtime.Command;
+import org.openstreetmap.atlas.utilities.runtime.CommandMap;
+import org.openstreetmap.atlas.utilities.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checks intersection of country boundary and shards to validate missing shards.
+ *
+ * @author james_gage
+ */
+public class AtlasMissingShardVerifier extends Command
+{
+    private static final Logger logger = LoggerFactory.getLogger(AtlasMissingShardVerifier.class);
+
+    private static final Switch<CountryBoundaryMap> BOUNDARIES = new Switch<>("boundaries",
+            "The country boundaries.", value -> initializeCountryBoundaryMap(value),
+            Optionality.REQUIRED);
+    private static final Switch<File> OUTPUT = new Switch<>("output", "The output file", File::new,
+            Optionality.REQUIRED);
+    private static final Switch<File> MISSING_SHARDS = new Switch<>("shards",
+            "Country shards that are listed as missing", File::new, Optionality.REQUIRED);
+
+    public static void main(final String[] args)
+    {
+        new AtlasMissingShardVerifier().run(args);
+    }
+
+    private static CountryBoundaryMap initializeCountryBoundaryMap(final String value)
+    {
+        final Time start = Time.now();
+        logger.info("Loading boundaries");
+        final CountryBoundaryMap result = new CountryBoundaryMap(new File(value));
+        logger.info("Loaded boundaries in {}", start.elapsedSince());
+        return result;
+    }
+
+    public int verifier(final CountryBoundaryMap boundaries,
+            final Set<CountryShard> missingCountryShards, final File output)
+    {
+        int returnCode = 0;
+        try (SafeBufferedWriter writer = output.writer())
+        {
+            for (final CountryShard countryShard : missingCountryShards)
+            {
+                logger.info(countryShard.toString());
+                final Clip clip = new Clip(ClipType.AND, countryShard.bounds(),
+                        boundaries.countryBoundary(countryShard.getCountry()).get(0).getBoundary());
+                if (clip.getClipMultiPolygon().surface().asDm7Squared() == 0)
+                {
+                    continue;
+                }
+                final MultiPolygon clipMulti = clip.getClipMultiPolygon();
+                final Rectangle clipBounds = clipMulti.bounds();
+                final OverpassClient client = new OverpassClient();
+                // Take in list of all nodes, then filter out nodes that aren't ingested into
+                // Atlas
+                final Time nodeStart = Time.now();
+                final List<OverpassOsmNode> nodeList = client
+                        .nodesFromQuery(OverpassClient.buildQuery("node", clipBounds));
+                logger.info("Node query finished in: " + nodeStart.elapsedSince());
+                final Time wayStart = Time.now();
+                final List<OverpassOsmWay> ways = client
+                        .waysFromQuery(OverpassClient.buildQuery("way", clipBounds));
+                logger.info("Way query finished in: " + wayStart.elapsedSince());
+                final Resource resource = new InputStreamResource(
+                        AtlasMissingShardVerifier.class.getResourceAsStream(
+                                "/org/openstreetmap/atlas/geography/atlas/pbf/osm-pbf-way.json"));
+                final Configuration configuration = new StandardConfiguration(resource);
+                final ConfiguredTaggableFilter filter = new ConfiguredTaggableFilter(configuration);
+                for (final OverpassOsmWay way : ways)
+                {
+                    final Taggable taggableWay = Taggable.with(way.getTags());
+                    if (!filter.test(taggableWay))
+                    {
+                        nodeList.removeIf(
+                                node -> way.getNodeIdentifiers().contains(node.getIdentifier()));
+                    }
+                }
+                for (final OverpassOsmNode node : nodeList)
+                {
+                    final Location nodeLocation = Location
+                            .forString(node.getLatitude() + "," + node.getLongitude());
+                    if (clipMulti.fullyGeometricallyEncloses(nodeLocation))
+                    {
+                        returnCode = -1;
+                        writer.writeLine(countryShard.toString());
+                        writer.writeLine(
+                                "Boundary/Shard intersection zone: " + clipMulti.toString());
+                        writer.writeLine("Id of relevant node geometry: " + node.getIdentifier());
+                        writer.writeLine("Node Location: " + nodeLocation.toString() + "\n");
+                        break;
+                    }
+                }
+            }
+        }
+        catch (final Exception e)
+        {
+            throw new CoreException("Could not match shards to boundaries", e);
+        }
+        return returnCode;
+    }
+
+    @Override
+    protected int onRun(final CommandMap command)
+    {
+        final CountryBoundaryMap boundaries = (CountryBoundaryMap) command.get(BOUNDARIES);
+        final File missingShardFile = (File) command.get(MISSING_SHARDS);
+        final File output = (File) command.get(OUTPUT);
+        final Set<CountryShard> missingCountryShards = missingShardFile.linesList().stream()
+                .map(CountryShard::forName).collect(Collectors.toSet());
+        final Time fullStart = Time.now();
+        final int returnCode;
+        try
+        {
+            returnCode = verifier(boundaries, missingCountryShards, output);
+        }
+        catch (final Exception e)
+        {
+            return -1;
+        }
+        logger.info("Verification ran in: " + fullStart.elapsedSince());
+        return returnCode;
+    }
+
+    @Override
+    protected SwitchList switches()
+    {
+        return new SwitchList().with(BOUNDARIES, OUTPUT, MISSING_SHARDS);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
@@ -33,7 +33,7 @@ import com.vividsolutions.jts.index.strtree.STRtree;
 /**
  * Checks intersection of country boundary and shards to validate missing shards.
  *
- * @author james_gage
+ * @author jwpgage
  */
 public class AtlasMissingShardVerifier extends Command
 {

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
@@ -24,7 +24,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 /**
- * @author james-gage
+ * @author jwpgage
  */
 public class OverpassClient
 {

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
@@ -14,6 +14,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.streaming.resource.http.GetResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -24,7 +26,10 @@ import org.xml.sax.SAXException;
  */
 public class OverpassClient
 {
-    private static final String BASE_QUERY = "http://overpass.kumi.systems/api/interpreter/?data=";
+    private static final Logger logger = LoggerFactory.getLogger(OverpassClient.class);
+
+    private static String SERVER = "-api.de";
+    private static String BASE_QUERY;
     private static final String END_QUERY = ");out body;";
 
     public static String buildCompoundQuery(final String type, final String key, final String value,
@@ -50,6 +55,20 @@ public class OverpassClient
     {
         return bounds.lowerLeft().getLatitude() + "," + bounds.upperLeft().getLongitude() + ","
                 + bounds.upperRight().getLatitude() + "," + bounds.lowerRight().getLongitude();
+    }
+
+    public OverpassClient()
+    {
+        initializeBaseQuery();
+    }
+
+    public OverpassClient(final String server)
+    {
+        if (server != null)
+        {
+            SERVER = server;
+        }
+        initializeBaseQuery();
     }
 
     public CloseableHttpResponse getResponse(final String specificQuery)
@@ -184,5 +203,11 @@ public class OverpassClient
             }
             return osmWays;
         }
+    }
+
+    private void initializeBaseQuery()
+    {
+        BASE_QUERY = "http://overpass" + SERVER + "/api/interpreter/?data=";
+        logger.info("Overpass Server Queried: " + BASE_QUERY);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
@@ -1,0 +1,188 @@
+package org.openstreetmap.atlas.generator.sharding;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.streaming.resource.http.GetResource;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * @author james-gage
+ */
+public class OverpassClient
+{
+    private static final String BASE_QUERY = "http://overpass.kumi.systems/api/interpreter/?data=";
+    private static final String END_QUERY = ");out body;";
+
+    public static String buildCompoundQuery(final String type, final String key, final String value,
+            final Rectangle bounds)
+    {
+        return type + "[\"" + key + "\"~\"" + value + "\"](" + constructBoundingBox(bounds)
+                + END_QUERY;
+    }
+
+    public static String buildQuery(final String type, final Rectangle bounds)
+    {
+        return type + "(" + constructBoundingBox(bounds) + END_QUERY;
+    }
+
+    public static String buildQuery(final String type, final String key, final String value,
+            final Rectangle bounds)
+    {
+        return type + "[\"" + key + "\"=\"" + value + "\"](" + constructBoundingBox(bounds)
+                + END_QUERY;
+    }
+
+    private static String constructBoundingBox(final Rectangle bounds)
+    {
+        return bounds.lowerLeft().getLatitude() + "," + bounds.upperLeft().getLongitude() + ","
+                + bounds.upperRight().getLatitude() + "," + bounds.lowerRight().getLongitude();
+    }
+
+    public CloseableHttpResponse getResponse(final String specificQuery)
+            throws UnsupportedEncodingException
+    {
+        final String query = BASE_QUERY + URLEncoder.encode(specificQuery, "UTF-8");
+        return new GetResource(query).getResponse();
+    }
+
+    /**
+     * Makes a way Overpass query, parses the response xml, and returns the identifiers of nodes
+     * that make up the ways that match the query
+     *
+     * @param query
+     *            The Overpass query.
+     * @return The identifiers of the nodes that make up all ways matching the query.
+     * @throws ParserConfigurationException
+     *             If a DocumentBuilder cannot be created which satisfies the configuration
+     *             requested.
+     * @throws UnsupportedOperationException
+     *             If any IO errors occur.
+     * @throws SAXException
+     *             If any parse errors occur.
+     * @throws IOException
+     *             If is is null.
+     */
+    public List<String> nodeIdsFromWayQuery(final String query) throws ParserConfigurationException,
+            UnsupportedOperationException, SAXException, IOException
+    {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder builder = factory.newDocumentBuilder();
+        try (CloseableHttpResponse response = this.getResponse(query))
+        {
+            final Document doc = builder.parse(response.getEntity().getContent());
+            final NodeList nodelist = doc.getElementsByTagName("nd");
+            final List<String> nodeIds = new ArrayList<>();
+            for (int i = 0; i < nodelist.getLength(); i++)
+            {
+                nodeIds.add(nodelist.item(i).getAttributes().item(0).getNodeValue());
+            }
+            return nodeIds;
+        }
+    }
+
+    /**
+     * Makes a node Overpass query, parses the response xml, and returns the nodes that match the
+     * query
+     *
+     * @param query
+     *            The node Overpass query.
+     * @return The nodes that match the query.
+     * @throws UnsupportedOperationException
+     *             If any IO errors occur.
+     * @throws SAXException
+     *             If any parse errors occur.
+     * @throws IOException
+     *             If is is null.
+     * @throws ParserConfigurationException
+     *             If a DocumentBuilder cannot be created which satisfies the configuration
+     *             requested.
+     */
+    public List<OverpassOsmNode> nodesFromQuery(final String query)
+            throws UnsupportedOperationException, SAXException, IOException,
+            ParserConfigurationException
+    {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder builder = factory.newDocumentBuilder();
+        try (CloseableHttpResponse response = this.getResponse(query))
+        {
+            final Document doc = builder.parse(response.getEntity().getContent());
+            final NodeList nodelist = doc.getElementsByTagName("node");
+            final List<OverpassOsmNode> osmNodes = new ArrayList<>();
+            for (int i = 0; i < nodelist.getLength(); i++)
+            {
+                final String osmIdentifier = nodelist.item(i).getAttributes().item(0)
+                        .getNodeValue();
+                final String latitude = nodelist.item(i).getAttributes().item(1).getNodeValue();
+                final String longitude = nodelist.item(i).getAttributes().item(2).getNodeValue();
+                osmNodes.add(new OverpassOsmNode(osmIdentifier, latitude, longitude));
+            }
+            return osmNodes;
+        }
+    }
+
+    /**
+     * Makes a way Overpass query, parses the response xml, and returns the ways that match the
+     * query
+     *
+     * @param query
+     *            The way Overpass query.
+     * @return The nodes that match the query
+     * @throws ParserConfigurationException
+     *             If a DocumentBuilder cannot be created which satisfies the configuration
+     *             requested.
+     * @throws IOException
+     *             If it is null.
+     * @throws UnsupportedOperationException
+     *             Of any IO errors occur.
+     * @throws SAXException
+     *             If any parse errors occur.
+     */
+    public List<OverpassOsmWay> waysFromQuery(final String query)
+            throws ParserConfigurationException, IOException, UnsupportedOperationException,
+            SAXException
+    {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder builder = factory.newDocumentBuilder();
+        try (CloseableHttpResponse response = this.getResponse(query))
+        {
+            final List<OverpassOsmWay> osmWays = new ArrayList<>();
+            final Document document = builder.parse(response.getEntity().getContent());
+            final NodeList wayNodeList = document.getElementsByTagName("way");
+            for (int i = 0; i < wayNodeList.getLength(); i++)
+            {
+                final Element wayElement = (Element) wayNodeList.item(i);
+                final String wayIdentifier = wayElement.getAttributes().item(0).getNodeValue();
+                final NodeList nodeNodeList = wayElement.getElementsByTagName("nd");
+                final List<String> nodeIdentifiers = new ArrayList<>();
+                for (int j = 0; j < nodeNodeList.getLength(); j++)
+                {
+                    nodeIdentifiers
+                            .add(nodeNodeList.item(j).getAttributes().item(0).getNodeValue());
+                }
+                final NodeList tagNodeList = wayElement.getElementsByTagName("tag");
+                final HashMap<String, String> tags = new HashMap<>();
+                for (int j = 0; j < tagNodeList.getLength(); j++)
+                {
+                    tags.put(tagNodeList.item(j).getAttributes().item(0).getNodeValue(),
+                            tagNodeList.item(j).getAttributes().item(1).getNodeValue());
+                }
+                osmWays.add(new OverpassOsmWay(wayIdentifier, nodeIdentifiers, tags));
+            }
+            return osmWays;
+        }
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassOsmNode.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassOsmNode.java
@@ -7,7 +7,7 @@ import java.util.Map;
  * This node represents an Osm Node returned from an overpass query. The node identifier, Location,
  * and tags are stored.
  *
- * @author james-gage
+ * @author jwpgage
  */
 public class OverpassOsmNode
 {

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassOsmNode.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassOsmNode.java
@@ -1,0 +1,75 @@
+package org.openstreetmap.atlas.generator.sharding;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This node represents an Osm Node returned from an overpass query. The node identifier, Location,
+ * and tags are stored.
+ *
+ * @author james-gage
+ */
+public class OverpassOsmNode
+{
+    private String osmIdentifier;
+    private String latitude;
+    private String longitude;
+    private final Map<String, String> tags;
+
+    public OverpassOsmNode(final String osmIdentifier, final String latitude,
+            final String longitude)
+    {
+        this(osmIdentifier, latitude, longitude, new HashMap<>());
+    }
+
+    public OverpassOsmNode(final String osmIdentifier, final String latitude,
+            final String longitude, final Map<String, String> tags)
+    {
+        this.osmIdentifier = osmIdentifier;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.tags = tags;
+    }
+
+    public String getIdentifier()
+    {
+        return this.osmIdentifier;
+    }
+
+    public String getLatitude()
+    {
+        return this.latitude;
+    }
+
+    public String getLongitude()
+    {
+        return this.longitude;
+    }
+
+    public Map<String, String> getTags()
+    {
+        return this.tags;
+    }
+
+    public void setIdentifier(final String osmIdentifier)
+    {
+        this.osmIdentifier = osmIdentifier;
+    }
+
+    public void setLatitude(final String latitude)
+    {
+        this.latitude = latitude;
+    }
+
+    public void setLongitude(final String longitude)
+    {
+        this.longitude = longitude;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ID=" + this.osmIdentifier + " LAT=" + this.latitude + " LON=" + this.longitude;
+    }
+
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassOsmWay.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassOsmWay.java
@@ -1,0 +1,63 @@
+package org.openstreetmap.atlas.generator.sharding;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * This way represents an osm way returned from an overpass query. The way identifier, the list of
+ * node identifiers that comprise the way, and the tags are stored.
+ *
+ * @author jamesgage
+ */
+public class OverpassOsmWay
+{
+    private String osmIdentifier;
+    private List<String> nodeIdentifiers;
+    private HashMap<String, String> tags = new HashMap<>();
+
+    public OverpassOsmWay(final String osmIdentifier, final List<String> nodeIdentifiers,
+            final HashMap<String, String> tags)
+    {
+        this.osmIdentifier = osmIdentifier;
+        this.nodeIdentifiers = nodeIdentifiers;
+        this.tags = tags;
+    }
+
+    public List<String> getNodeIdentifiers()
+    {
+        return this.nodeIdentifiers;
+    }
+
+    public String getOsmIdentifier()
+    {
+        return this.osmIdentifier;
+    }
+
+    public HashMap<String, String> getTags()
+    {
+        return this.tags;
+    }
+
+    public void setNodeIdentifiers(final List<String> nodeIdentifiers)
+    {
+        this.nodeIdentifiers = nodeIdentifiers;
+    }
+
+    public void setOsmIdentifier(final String osmIdentifier)
+    {
+        this.osmIdentifier = osmIdentifier;
+    }
+
+    public void setTags(final HashMap<String, String> tags)
+    {
+        this.tags = tags;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ID: " + this.osmIdentifier + "\nNodes: " + this.nodeIdentifiers.toString()
+                + "\nTags: " + this.tags.toString() + "\n";
+    }
+
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassOsmWay.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassOsmWay.java
@@ -7,7 +7,7 @@ import java.util.List;
  * This way represents an osm way returned from an overpass query. The way identifier, the list of
  * node identifiers that comprise the way, and the tags are stored.
  *
- * @author jamesgage
+ * @author jwpgage
  */
 public class OverpassOsmWay
 {


### PR DESCRIPTION
`AtlasMissingShardVerifier` takes the list of missing shards generated by `AtlasShardVerifier`, and checks to see if these shards are missing because they are empty, or because they failed to build. It does this by:

 * Finding the multi polygon of intersection between a shard and country boundary
 * Querying Overpass for all nodes within that bounding box
 * Querying Overpass for all ways within that bounding box
 * Subtracting nodes that are a part of ways that are not ingested into atlas (coastlines, boundaries, etc) from the set of all nodes within the bounding box
 * If any nodes remain within the multipolygon of intersection after filtering, then the shard was not empty and should have been generated
 * The verification returns the list of non empty shards from the missing shards list, along with information about the geometry that proves the shard should have been created.

Also included are classes `OverpassClient`, `OverpassOsmNode`, and `OverpassOsmWay`, which are used query and store information from Overpass respectively.