### PR TITLE
HDFSWalker should take in max depth for traversal

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalker.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalker.java
@@ -22,8 +22,8 @@ import com.google.common.collect.AbstractIterator;
 /**
  * Inspired by Files.walk
  * (https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#walk-java.nio.file.Path-int-
- * java.nio.file.FileVisitOption...-), either retrieve a Stream of HDFS file
- * status objects or convert them to HDFSFile objects.
+ * java.nio.file.FileVisitOption...-), either retrieve a Stream of HDFS file status objects or
+ * convert them to HDFSFile objects.
  *
  * @author cstaylor
  * @author jklamer
@@ -31,184 +31,186 @@ import com.google.common.collect.AbstractIterator;
  */
 public final class HDFSWalker
 {
-	/**
-	 * Collection of hadoop file status object and it's corresponding depth in
-	 * the filesystem hierarchy
-	 *
-	 * @author sbhalekar
-	 */
-	private static final class FileStatusAtDepth
-	{
-		private final FileStatus fileStatus;
-		private final int fileDepth;
+    /**
+     * Collection of hadoop file status object and it's corresponding depth in the filesystem
+     * hierarchy
+     *
+     * @author sbhalekar
+     */
+    private static final class FileStatusAtDepth
+    {
+        private final int fileDepth;
+        private final FileStatus fileStatus;
 
-		private FileStatusAtDepth(final FileStatus fileStatus, final int fileLevel)
-		{
-			this.fileStatus = fileStatus;
-			this.fileDepth = fileLevel;
-		}
+        private FileStatusAtDepth(final FileStatus fileStatus, final int fileLevel)
+        {
+            this.fileStatus = fileStatus;
+            this.fileDepth = fileLevel;
+        }
 
-		public int getFileDepth()
-		{
-			return this.fileDepth;
-		}
+        public int getFileDepth()
+        {
+            return this.fileDepth;
+        }
 
-		public FileStatus getFileStatus()
-		{
-			return this.fileStatus;
-		}
-	}
+        public FileStatus getFileStatus()
+        {
+            return this.fileStatus;
+        }
+    }
 
-	/**
-	 * Iterator for BFS over a collection of HDFS files and directories
-	 *
-	 * @author cstaylor
-	 */
-	private static final class HDFSIterator extends AbstractIterator<FileStatus>
-	{
+    /**
+     * Iterator for BFS over a collection of HDFS files and directories
+     *
+     * @author cstaylor
+     */
+    private static final class HDFSIterator extends AbstractIterator<FileStatus>
+    {
 
-		/**
-		 * This variable represents the depth for all the children of root
-		 * directory
-		 */
-		private static final int ONE = 1;
+        /**
+         * This variable represents the depth for all the children of root directory
+         */
+        private static final int ONE = 1;
 
-		private final Queue<FileStatusAtDepth> currentPaths;
+        private final Queue<FileStatusAtDepth> currentPaths;
 
-		private final FileSystem fileSystem;
+        private final FileSystem fileSystem;
 
-		/**
-		 * Limit to stop traversing the hadoop directory hierarchy. All the file
-		 * paths would be explored if this limit exceeds the max depth in
-		 * filesystem hierarchy. Root will always have a depth of 0.
-		 */
-		private final int maxDepth;
+        /**
+         * Limit to stop traversing the hadoop directory hierarchy. All the file paths would be
+         * explored if this limit exceeds the max depth in filesystem hierarchy. Root will always
+         * have a depth of 0.
+         */
+        private final int maxDepth;
 
-		private HDFSIterator(final Path root, final Configuration configuration)
-		{
-			this(root, configuration, HDFSWalker.WALK_ALL);
-		}
+        private HDFSIterator(final Path root, final Configuration configuration)
+        {
+            this(root, configuration, HDFSWalker.WALK_ALL);
+        }
 
-		private HDFSIterator(final Path root, final Configuration configuration, int maxDepth)
-		{
-			if (root == null)
-			{
-				throw new CoreException("Error when creating an HDFSIterator: root can't be null");
-			}
-			this.maxDepth = maxDepth;
+        private HDFSIterator(final Path root, final Configuration configuration, final int maxDepth)
+        {
+            if (root == null)
+            {
+                throw new CoreException("Error when creating an HDFSIterator: root can't be null");
+            }
+            this.maxDepth = maxDepth;
 
-			try 
-			{
-				this.currentPaths = new LinkedList<>();
-				this.fileSystem = root.getFileSystem(configuration);
-				// Files at depth 1 will be traversed all the time
-				Stream.of(this.fileSystem.listStatus(root))
-						.forEach(status -> this.currentPaths.add(new FileStatusAtDepth(status, ONE)));
-			} 
-			catch (final IOException oops)
-			{
-				throw new CoreException("Error when creating an HDFSIterator", oops);
-			}
-		}
+            try
+            {
+                this.currentPaths = new LinkedList<>();
+                this.fileSystem = root.getFileSystem(configuration);
+                // Files at depth 1 will be traversed all the time
+                Stream.of(this.fileSystem.listStatus(root)).forEach(
+                        status -> this.currentPaths.add(new FileStatusAtDepth(status, ONE)));
+            }
+            catch (final IOException oops)
+            {
+                throw new CoreException("Error when creating an HDFSIterator", oops);
+            }
+        }
 
-		@Override
-		protected FileStatus computeNext()
-		{
-			if (this.currentPaths.isEmpty())
-			{
-				return endOfData();
-			}
+        @Override
+        protected FileStatus computeNext()
+        {
+            if (this.currentPaths.isEmpty())
+            {
+                return endOfData();
+            }
 
-			final FileStatusAtDepth returnValue = this.currentPaths.remove();
-			final FileStatus currentFileStatus = returnValue.getFileStatus();
-			final int currentFileDepth = returnValue.getFileDepth();
+            final FileStatusAtDepth returnValue = this.currentPaths.remove();
+            final FileStatus currentFileStatus = returnValue.getFileStatus();
+            final int currentFileDepth = returnValue.getFileDepth();
 
-			if (currentFileStatus.isDirectory())
-			{
-				int childDepth = currentFileDepth + ONE;
-				// Add the children only if they are below the threshold depth
-				// or the threshold is not specified at all
-				if (this.maxDepth == HDFSWalker.WALK_ALL || childDepth <= this.maxDepth)
-				{
-					try
-					{
-						Stream.of(this.fileSystem.listStatus(currentFileStatus.getPath()))
-								.forEach(status -> this.currentPaths.add(new FileStatusAtDepth(status, childDepth)));
-					}
-					catch (final IOException oops)
-					{
-						throw new CoreException("Can't locate children of {}", currentFileStatus, oops);
-					}
-				}
-			}
-			return currentFileStatus;
-		}
-	}
+            if (currentFileStatus.isDirectory())
+            {
+                final int childDepth = currentFileDepth + ONE;
+                // Add the children only if they are below the threshold depth
+                // or the threshold is not specified at all
+                if (this.maxDepth == HDFSWalker.WALK_ALL || childDepth <= this.maxDepth)
+                {
+                    try
+                    {
+                        Stream.of(this.fileSystem.listStatus(currentFileStatus.getPath()))
+                                .forEach(status -> this.currentPaths
+                                        .add(new FileStatusAtDepth(status, childDepth)));
+                    }
+                    catch (final IOException oops)
+                    {
+                        throw new CoreException("Can't locate children of {}", currentFileStatus,
+                                oops);
+                    }
+                }
+            }
+            return currentFileStatus;
+        }
+    }
 
-	private Configuration configuration;
-	private final int maxDepth;
-	public static final int WALK_ALL = -1;
+    public static final int WALK_ALL = -1;
+    private Configuration configuration;
+    private final int maxDepth;
 
-	public HDFSWalker()
-	{
-		this.maxDepth = WALK_ALL;
-	}
+    public static HDFSFile convert(final FileStatus status)
+    {
+        try
+        {
+            return new HDFSFile(status.getPath());
+        }
+        catch (final IOException oops)
+        {
+            throw new CoreException("Error when converting FileStatus to HDFSFile", oops);
+        }
+    }
 
-	public HDFSWalker(int maxDepth)
-	{
-		this.maxDepth = maxDepth;
-	}
+    public static Function<FileStatus, FileStatus> debug(final Consumer<String> printer)
+    {
+        return status ->
+        {
+            final char type = status.isSymlink() ? 'S' : status.isDirectory() ? 'D' : 'F';
+            printer.accept(String.format("[%c] %s", type, status.getPath()));
+            return status;
+        };
+    }
 
-	public static HDFSFile convert(final FileStatus status)
-	{
-		try
-		{
-			return new HDFSFile(status.getPath());
-		}
-		catch (final IOException oops)
-		{
-			throw new CoreException("Error when converting FileStatus to HDFSFile", oops);
-		}
-	}
+    public static Function<FileStatus, FileStatus> size(final AtomicLong value)
+    {
+        return status ->
+        {
+            value.addAndGet(status.getLen());
+            return status;
+        };
+    }
 
-	public static Function<FileStatus, FileStatus> debug(final Consumer<String> printer)
-	{
-		return status ->
-		{
-			final char type = status.isSymlink() ? 'S' : status.isDirectory() ? 'D' : 'F';
-			printer.accept(String.format("[%c] %s", type, status.getPath()));
-			return status;
-		};
-	}
+    public HDFSWalker()
+    {
+        this.maxDepth = WALK_ALL;
+    }
 
-	public static Function<FileStatus, FileStatus> size(final AtomicLong value)
-	{
-		return status ->
-		{
-			value.addAndGet(status.getLen());
-			return status;
-		};
-	}
+    public HDFSWalker(final int maxDepth)
+    {
+        this.maxDepth = maxDepth;
+    }
 
-	public HDFSWalker usingConfiguration(final Configuration configuration)
-	{
-		this.configuration = configuration;
-		return this;
-	}
+    public HDFSWalker usingConfiguration(final Configuration configuration)
+    {
+        this.configuration = configuration;
+        return this;
+    }
 
-	public Stream<FileStatus> walk(final Path root)
-	{
-		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(
-				new HDFSIterator(root, getConfiguration(), this.maxDepth), Spliterator.ORDERED), false);
-	}
+    public Stream<FileStatus> walk(final Path root)
+    {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+                new HDFSIterator(root, getConfiguration(), this.maxDepth), Spliterator.ORDERED),
+                false);
+    }
 
-	public Stream<HDFSFile> walkFiles(final Path root)
-	{
-		return walk(root).filter(FileStatus::isFile).map(HDFSWalker::convert);
-	}
+    public Stream<HDFSFile> walkFiles(final Path root)
+    {
+        return walk(root).filter(FileStatus::isFile).map(HDFSWalker::convert);
+    }
 
-	private Configuration getConfiguration()
-	{
-		return this.configuration == null ? new Configuration() : this.configuration;
-	}
+    private Configuration getConfiguration()
+    {
+        return this.configuration == null ? new Configuration() : this.configuration;
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalker.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalker.java
@@ -22,122 +22,159 @@ import com.google.common.collect.AbstractIterator;
 /**
  * Inspired by Files.walk
  * (https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#walk-java.nio.file.Path-int-
- * java.nio.file.FileVisitOption...-), either retrieve a Stream of HDFS file status objects or
- * convert them to HDFSFile objects.
+ * java.nio.file.FileVisitOption...-), either retrieve a Stream of HDFS file
+ * status objects or convert them to HDFSFile objects.
  *
  * @author cstaylor
  * @author jklamer
+ * @author sbhalekar
  */
-public final class HDFSWalker
-{
-    /**
-     * Iterator for BFS over a collection of HDFS files and directories
-     *
-     * @author cstaylor
-     */
-    private static final class HDFSIterator extends AbstractIterator<FileStatus>
-    {
-        private final Queue<FileStatus> currentPaths;
+public final class HDFSWalker {
+	/**
+	 * Collection of hadoop file status object and it's corresponding depth in
+	 * the filesystem hierarchy
+	 *
+	 * @author sbhalekar
+	 */
+	private static final class FileStatusAtDepth {
+		private final FileStatus fileStatus;
+		private final int fileDepth;
 
-        private final FileSystem fileSystem;
+		private FileStatusAtDepth(final FileStatus fileStatus, final int fileLevel) {
+			this.fileStatus = fileStatus;
+			this.fileDepth = fileLevel;
+		}
 
-        private HDFSIterator(final Path root, final Configuration configuration)
-        {
-            if (root == null)
-            {
-                throw new CoreException("Error when creating an HDFSIterator: root can't be null");
-            }
+		public int getFileDepth() {
+			return this.fileDepth;
+		}
 
-            try
-            {
-                this.currentPaths = new LinkedList<>();
-                this.fileSystem = root.getFileSystem(configuration);
-                Stream.of(this.fileSystem.listStatus(root))
-                        .forEach(status -> this.currentPaths.add(status));
-            }
-            catch (final IOException oops)
-            {
-                throw new CoreException("Error when creating an HDFSIterator", oops);
-            }
-        }
+		public FileStatus getFileStatus() {
+			return this.fileStatus;
+		}
+	}
 
-        @Override
-        protected FileStatus computeNext()
-        {
-            if (this.currentPaths.isEmpty())
-            {
-                return endOfData();
-            }
+	/**
+	 * Iterator for BFS over a collection of HDFS files and directories
+	 *
+	 * @author cstaylor
+	 */
+	private static final class HDFSIterator extends AbstractIterator<FileStatus> {
 
-            final FileStatus returnValue = this.currentPaths.remove();
-            if (returnValue.isDirectory())
-            {
-                try
-                {
-                    Stream.of(this.fileSystem.listStatus(returnValue.getPath()))
-                            .forEach(status -> this.currentPaths.add(status));
-                }
-                catch (final IOException oops)
-                {
-                    throw new CoreException("Can't locate children of {}", returnValue, oops);
-                }
-            }
-            return returnValue;
-        }
-    }
+		/**
+		 * This variable represents the depth for all the children of root
+		 * directory
+		 */
+		private static final int ONE = 1;
 
-    private Configuration configuration;
+		private final Queue<FileStatusAtDepth> currentPaths;
 
-    public static HDFSFile convert(final FileStatus status)
-    {
-        try
-        {
-            return new HDFSFile(status.getPath());
-        }
-        catch (final IOException oops)
-        {
-            throw new CoreException("Error when converting FileStatus to HDFSFile", oops);
-        }
-    }
+		private final FileSystem fileSystem;
 
-    public static Function<FileStatus, FileStatus> debug(final Consumer<String> printer)
-    {
-        return status ->
-        {
-            final char type = status.isSymlink() ? 'S' : status.isDirectory() ? 'D' : 'F';
-            printer.accept(String.format("[%c] %s", type, status.getPath()));
-            return status;
-        };
-    }
+		/**
+		 * Limit to stop traversing the hadoop directory hierarchy. All the file
+		 * paths would be explored if this limit exceeds the max depth in
+		 * filesystem hierarchy. Root will always have a depth of 0.
+		 */
+		private final int maxDepth;
 
-    public static Function<FileStatus, FileStatus> size(final AtomicLong value)
-    {
-        return status ->
-        {
-            value.addAndGet(status.getLen());
-            return status;
-        };
-    }
+		private HDFSIterator(final Path root, final Configuration configuration) {
+			this(root, configuration, HDFSWalker.WALK_ALL);
+		}
 
-    public HDFSWalker usingConfiguration(final Configuration configuration)
-    {
-        this.configuration = configuration;
-        return this;
-    }
+		private HDFSIterator(final Path root, final Configuration configuration, int maxDepth) {
+			if (root == null) {
+				throw new CoreException("Error when creating an HDFSIterator: root can't be null");
+			}
+			this.maxDepth = maxDepth;
 
-    public Stream<FileStatus> walk(final Path root)
-    {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(
-                new HDFSIterator(root, getConfiguration()), Spliterator.ORDERED), false);
-    }
+			try {
+				this.currentPaths = new LinkedList<>();
+				this.fileSystem = root.getFileSystem(configuration);
+				// Files at depth 1 will be traversed all the time
+				Stream.of(this.fileSystem.listStatus(root))
+						.forEach(status -> this.currentPaths.add(new FileStatusAtDepth(status, ONE)));
+			} catch (final IOException oops) {
+				throw new CoreException("Error when creating an HDFSIterator", oops);
+			}
+		}
 
-    public Stream<HDFSFile> walkFiles(final Path root)
-    {
-        return walk(root).filter(FileStatus::isFile).map(HDFSWalker::convert);
-    }
+		@Override
+		protected FileStatus computeNext() {
+			if (this.currentPaths.isEmpty()) {
+				return endOfData();
+			}
 
-    private Configuration getConfiguration()
-    {
-        return this.configuration == null ? new Configuration() : this.configuration;
-    }
+			final FileStatusAtDepth returnValue = this.currentPaths.remove();
+			final FileStatus currentFileStatus = returnValue.getFileStatus();
+			final int currentFileDepth = returnValue.getFileDepth();
+
+			if (currentFileStatus.isDirectory()) {
+				int childDepth = currentFileDepth + ONE;
+				// Add the children only if they are below the threshold depth
+				// or the threshold is not specified at all
+				if (this.maxDepth == HDFSWalker.WALK_ALL || childDepth <= this.maxDepth)
+					try {
+						Stream.of(this.fileSystem.listStatus(currentFileStatus.getPath()))
+								.forEach(status -> this.currentPaths.add(new FileStatusAtDepth(status, childDepth)));
+					} catch (final IOException oops) {
+						throw new CoreException("Can't locate children of {}", currentFileStatus, oops);
+					}
+			}
+			return currentFileStatus;
+		}
+	}
+
+	private Configuration configuration;
+	private final int maxDepth;
+	public static final int WALK_ALL = -1;
+
+	public HDFSWalker() {
+		this.maxDepth = WALK_ALL;
+	}
+
+	public HDFSWalker(int maxDepth) {
+		this.maxDepth = maxDepth;
+	}
+
+	public static HDFSFile convert(final FileStatus status) {
+		try {
+			return new HDFSFile(status.getPath());
+		} catch (final IOException oops) {
+			throw new CoreException("Error when converting FileStatus to HDFSFile", oops);
+		}
+	}
+
+	public static Function<FileStatus, FileStatus> debug(final Consumer<String> printer) {
+		return status -> {
+			final char type = status.isSymlink() ? 'S' : status.isDirectory() ? 'D' : 'F';
+			printer.accept(String.format("[%c] %s", type, status.getPath()));
+			return status;
+		};
+	}
+
+	public static Function<FileStatus, FileStatus> size(final AtomicLong value) {
+		return status -> {
+			value.addAndGet(status.getLen());
+			return status;
+		};
+	}
+
+	public HDFSWalker usingConfiguration(final Configuration configuration) {
+		this.configuration = configuration;
+		return this;
+	}
+
+	public Stream<FileStatus> walk(final Path root) {
+		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+				new HDFSIterator(root, getConfiguration(), this.maxDepth), Spliterator.ORDERED), false);
+	}
+
+	public Stream<HDFSFile> walkFiles(final Path root) {
+		return walk(root).filter(FileStatus::isFile).map(HDFSWalker::convert);
+	}
+
+	private Configuration getConfiguration() {
+		return this.configuration == null ? new Configuration() : this.configuration;
+	}
 }

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
@@ -16,23 +16,28 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
  * @author mkalender
  * @author sbhalekar
  */
-public class HDFSWalkerTest {
-	private static Tuple<List<FileStatus>, List<String>> test(final File directory) {
+public class HDFSWalkerTest
+{
+	private static Tuple<List<FileStatus>, List<String>> test(final File directory)
+	{
 		return test(directory, HDFSWalker.WALK_ALL);
 	}
 
-	private static Tuple<List<FileStatus>, List<String>> test(final File directory, final int depth) {
+	private static Tuple<List<FileStatus>, List<String>> test(final File directory, final int depth)
+	{
 		final List<FileStatus> fileStatusList = new ArrayList<>();
 		final List<String> debugStrings = new ArrayList<>();
 		new HDFSWalker(depth).walk(new Path(directory.getPath())).map(HDFSWalker.debug(debugStrings::add))
-				.forEach(status -> {
+				.forEach(status ->
+				{
 					fileStatusList.add(status);
 				});
 		return Tuple.createTuple(fileStatusList, debugStrings);
 	}
 
 	@Test
-	public void testDirectoryListingWithMaxDepth() {
+	public void testDirectoryListingWithMaxDepth()
+	{
 		final File rootDirectory = File.temporaryFolder();
 		final File pathOne = rootDirectory.child("test-a");
 		final File pathTwo = rootDirectory.child("test-b");
@@ -58,7 +63,8 @@ public class HDFSWalkerTest {
 	}
 
 	@Test
-	public void testDirectoryWithAFile() {
+	public void testDirectoryWithAFile()
+	{
 		final File directory = File.temporaryFolder();
 		directory.child("test.tmp").writeAndClose("test file");
 		final Tuple<List<FileStatus>, List<String>> results = test(directory);
@@ -78,7 +84,8 @@ public class HDFSWalkerTest {
 	}
 
 	@Test
-	public void testDirectoryWithAFileInsideAChildDirectory() {
+	public void testDirectoryWithAFileInsideAChildDirectory()
+	{
 		final File directory = File.temporaryFolder();
 		directory.child("test.tmp").writeAndClose("test file");
 		final File childDirectory = directory.child("child-directory");
@@ -105,7 +112,8 @@ public class HDFSWalkerTest {
 	}
 
 	@Test
-	public void testEmptyDirectory() {
+	public void testEmptyDirectory()
+	{
 		final File emptyDirectory = File.temporaryFolder();
 		final Tuple<List<FileStatus>, List<String>> results = test(emptyDirectory);
 

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
@@ -18,108 +18,109 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
  */
 public class HDFSWalkerTest
 {
-	private static Tuple<List<FileStatus>, List<String>> test(final File directory)
-	{
-		return test(directory, HDFSWalker.WALK_ALL);
-	}
+    private static Tuple<List<FileStatus>, List<String>> test(final File directory)
+    {
+        return HDFSWalkerTest.test(directory, HDFSWalker.WALK_ALL);
+    }
 
-	private static Tuple<List<FileStatus>, List<String>> test(final File directory, final int depth)
-	{
-		final List<FileStatus> fileStatusList = new ArrayList<>();
-		final List<String> debugStrings = new ArrayList<>();
-		new HDFSWalker(depth).walk(new Path(directory.getPath())).map(HDFSWalker.debug(debugStrings::add))
-				.forEach(status ->
-				{
-					fileStatusList.add(status);
-				});
-		return Tuple.createTuple(fileStatusList, debugStrings);
-	}
+    private static Tuple<List<FileStatus>, List<String>> test(final File directory, final int depth)
+    {
+        final List<FileStatus> fileStatusList = new ArrayList<>();
+        final List<String> debugStrings = new ArrayList<>();
+        new HDFSWalker(depth).walk(new Path(directory.getPath()))
+                .map(HDFSWalker.debug(debugStrings::add)).forEach(status ->
+                {
+                    fileStatusList.add(status);
+                });
+        return Tuple.createTuple(fileStatusList, debugStrings);
+    }
 
-	@Test
-	public void testDirectoryListingWithMaxDepth()
-	{
-		final File rootDirectory = File.temporaryFolder();
-		final File pathOne = rootDirectory.child("test-a");
-		final File pathTwo = rootDirectory.child("test-b");
-		pathOne.mkdirs();
-		pathTwo.mkdirs();
-		pathOne.child("test-a.tmp").writeAndClose("test file");
-		pathTwo.child("test-b.tmp").writeAndClose("test file");
+    @Test
+    public void testDirectoryListingWithMaxDepth()
+    {
+        final File rootDirectory = File.temporaryFolder();
+        final File pathOne = rootDirectory.child("test-a");
+        final File pathTwo = rootDirectory.child("test-b");
+        pathOne.mkdirs();
+        pathTwo.mkdirs();
+        pathOne.child("test-a.tmp").writeAndClose("test file");
+        pathTwo.child("test-b.tmp").writeAndClose("test file");
 
-		// This should return only 2 child directories of the rootDirectory
-		Tuple<List<FileStatus>, List<String>> results = test(rootDirectory, 1);
+        // This should return only 2 child directories of the rootDirectory
+        Tuple<List<FileStatus>, List<String>> results = HDFSWalkerTest.test(rootDirectory, 1);
 
-		Assert.assertFalse(results.getFirst().isEmpty());
-		Assert.assertEquals(2, results.getFirst().size());
+        Assert.assertFalse(results.getFirst().isEmpty());
+        Assert.assertEquals(2, results.getFirst().size());
 
-		// This should list all the directories and files in those directories
-		// in the root hierarchy
-		results = test(rootDirectory);
+        // This should list all the directories and files in those directories
+        // in the root hierarchy
+        results = HDFSWalkerTest.test(rootDirectory);
 
-		Assert.assertFalse(results.getFirst().isEmpty());
-		Assert.assertEquals(4, results.getFirst().size());
+        Assert.assertFalse(results.getFirst().isEmpty());
+        Assert.assertEquals(4, results.getFirst().size());
 
-		pathOne.deleteRecursively();
-	}
+        pathOne.deleteRecursively();
+    }
 
-	@Test
-	public void testDirectoryWithAFile()
-	{
-		final File directory = File.temporaryFolder();
-		directory.child("test.tmp").writeAndClose("test file");
-		final Tuple<List<FileStatus>, List<String>> results = test(directory);
+    @Test
+    public void testDirectoryWithAFile()
+    {
+        final File directory = File.temporaryFolder();
+        directory.child("test.tmp").writeAndClose("test file");
+        final Tuple<List<FileStatus>, List<String>> results = HDFSWalkerTest.test(directory);
 
-		// Verify file statuses
-		Assert.assertFalse(results.getFirst().isEmpty());
-		Assert.assertEquals(1, results.getFirst().size());
+        // Verify file statuses
+        Assert.assertFalse(results.getFirst().isEmpty());
+        Assert.assertEquals(1, results.getFirst().size());
 
-		// Verify debug strings
-		Assert.assertFalse(results.getSecond().isEmpty());
-		Assert.assertEquals(1, results.getSecond().size());
-		Assert.assertEquals(String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp"),
-				results.getSecond().get(0));
+        // Verify debug strings
+        Assert.assertFalse(results.getSecond().isEmpty());
+        Assert.assertEquals(1, results.getSecond().size());
+        Assert.assertEquals(
+                String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp"),
+                results.getSecond().get(0));
 
-		// Clean up
-		directory.deleteRecursively();
-	}
+        // Clean up
+        directory.deleteRecursively();
+    }
 
-	@Test
-	public void testDirectoryWithAFileInsideAChildDirectory()
-	{
-		final File directory = File.temporaryFolder();
-		directory.child("test.tmp").writeAndClose("test file");
-		final File childDirectory = directory.child("child-directory");
-		Assert.assertTrue(childDirectory.mkdirs());
-		childDirectory.child("file-in-child-directory.tmp").writeAndClose("test child file");
+    @Test
+    public void testDirectoryWithAFileInsideAChildDirectory()
+    {
+        final File directory = File.temporaryFolder();
+        directory.child("test.tmp").writeAndClose("test file");
+        final File childDirectory = directory.child("child-directory");
+        Assert.assertTrue(childDirectory.mkdirs());
+        childDirectory.child("file-in-child-directory.tmp").writeAndClose("test child file");
 
-		// Verify file statuses
-		final Tuple<List<FileStatus>, List<String>> results = test(directory);
-		Assert.assertFalse(results.getFirst().isEmpty());
-		Assert.assertEquals(3, results.getFirst().size());
+        // Verify file statuses
+        final Tuple<List<FileStatus>, List<String>> results = HDFSWalkerTest.test(directory);
+        Assert.assertFalse(results.getFirst().isEmpty());
+        Assert.assertEquals(3, results.getFirst().size());
 
-		// Verify debug strings
-		Assert.assertFalse(results.getSecond().isEmpty());
-		Assert.assertEquals(3, results.getSecond().size());
-		Assert.assertTrue(results.getSecond()
-				.contains(String.format("[D] file:%s/%s", directory.getAbsolutePath(), "child-directory")));
-		Assert.assertTrue(results.getSecond().contains(
-				String.format("[F] file:%s/%s", childDirectory.getAbsolutePath(), "file-in-child-directory.tmp")));
-		Assert.assertTrue(
-				results.getSecond().contains(String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp")));
+        // Verify debug strings
+        Assert.assertFalse(results.getSecond().isEmpty());
+        Assert.assertEquals(3, results.getSecond().size());
+        Assert.assertTrue(results.getSecond().contains(
+                String.format("[D] file:%s/%s", directory.getAbsolutePath(), "child-directory")));
+        Assert.assertTrue(results.getSecond().contains(String.format("[F] file:%s/%s",
+                childDirectory.getAbsolutePath(), "file-in-child-directory.tmp")));
+        Assert.assertTrue(results.getSecond().contains(
+                String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp")));
 
-		// Clean up
-		directory.deleteRecursively();
-	}
+        // Clean up
+        directory.deleteRecursively();
+    }
 
-	@Test
-	public void testEmptyDirectory()
-	{
-		final File emptyDirectory = File.temporaryFolder();
-		final Tuple<List<FileStatus>, List<String>> results = test(emptyDirectory);
+    @Test
+    public void testEmptyDirectory()
+    {
+        final File emptyDirectory = File.temporaryFolder();
+        final Tuple<List<FileStatus>, List<String>> results = HDFSWalkerTest.test(emptyDirectory);
 
-		// Verify status and debug strings are empty
-		Assert.assertTrue(results.getFirst().isEmpty());
-		Assert.assertTrue(results.getSecond().isEmpty());
-		emptyDirectory.deleteRecursively();
-	}
+        // Verify status and debug strings are empty
+        Assert.assertTrue(results.getFirst().isEmpty());
+        Assert.assertTrue(results.getSecond().isEmpty());
+        emptyDirectory.deleteRecursively();
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
@@ -14,80 +14,104 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
  * Tests for {@link HDFSWalker}.
  *
  * @author mkalender
+ * @author sbhalekar
  */
-public class HDFSWalkerTest
-{
-    private static Tuple<List<FileStatus>, List<String>> test(final File directory)
-    {
-        final List<FileStatus> fileStatusList = new ArrayList<>();
-        final List<String> debugStrings = new ArrayList<>();
-        new HDFSWalker().walk(new Path(directory.getPath()))
-                .map(HDFSWalker.debug(debugStrings::add)).forEach(status ->
-                {
-                    fileStatusList.add(status);
-                });
-        return Tuple.createTuple(fileStatusList, debugStrings);
-    }
+public class HDFSWalkerTest {
+	private static Tuple<List<FileStatus>, List<String>> test(final File directory) {
+		return test(directory, HDFSWalker.WALK_ALL);
+	}
 
-    @Test
-    public void testDirectoryWithAFile()
-    {
-        final File directory = File.temporaryFolder();
-        directory.child("test.tmp").writeAndClose("test file");
-        final Tuple<List<FileStatus>, List<String>> results = test(directory);
+	private static Tuple<List<FileStatus>, List<String>> test(final File directory, final int depth) {
+		final List<FileStatus> fileStatusList = new ArrayList<>();
+		final List<String> debugStrings = new ArrayList<>();
+		new HDFSWalker(depth).walk(new Path(directory.getPath())).map(HDFSWalker.debug(debugStrings::add))
+				.forEach(status -> {
+					fileStatusList.add(status);
+				});
+		return Tuple.createTuple(fileStatusList, debugStrings);
+	}
 
-        // Verify file statuses
-        Assert.assertFalse(results.getFirst().isEmpty());
-        Assert.assertEquals(1, results.getFirst().size());
+	@Test
+	public void testDirectoryListingWithMaxDepth() {
+		final File rootDirectory = File.temporaryFolder();
+		final File pathOne = rootDirectory.child("test-a");
+		final File pathTwo = rootDirectory.child("test-b");
+		pathOne.mkdirs();
+		pathTwo.mkdirs();
+		pathOne.child("test-a.tmp").writeAndClose("test file");
+		pathTwo.child("test-b.tmp").writeAndClose("test file");
 
-        // Verify debug strings
-        Assert.assertFalse(results.getSecond().isEmpty());
-        Assert.assertEquals(1, results.getSecond().size());
-        Assert.assertEquals(
-                String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp"),
-                results.getSecond().get(0));
+		// This should return only 2 child directories of the rootDirectory
+		Tuple<List<FileStatus>, List<String>> results = test(rootDirectory, 1);
 
-        // Clean up
-        directory.deleteRecursively();
-    }
+		Assert.assertFalse(results.getFirst().isEmpty());
+		Assert.assertEquals(2, results.getFirst().size());
 
-    @Test
-    public void testDirectoryWithAFileInsideAChildDirectory()
-    {
-        final File directory = File.temporaryFolder();
-        directory.child("test.tmp").writeAndClose("test file");
-        final File childDirectory = directory.child("child-directory");
-        Assert.assertTrue(childDirectory.mkdirs());
-        childDirectory.child("file-in-child-directory.tmp").writeAndClose("test child file");
+		// This should list all the directories and files in those directories
+		// in the root hierarchy
+		results = test(rootDirectory);
 
-        // Verify file statuses
-        final Tuple<List<FileStatus>, List<String>> results = test(directory);
-        Assert.assertFalse(results.getFirst().isEmpty());
-        Assert.assertEquals(3, results.getFirst().size());
+		Assert.assertFalse(results.getFirst().isEmpty());
+		Assert.assertEquals(4, results.getFirst().size());
 
-        // Verify debug strings
-        Assert.assertFalse(results.getSecond().isEmpty());
-        Assert.assertEquals(3, results.getSecond().size());
-        Assert.assertTrue(results.getSecond().contains(
-                String.format("[D] file:%s/%s", directory.getAbsolutePath(), "child-directory")));
-        Assert.assertTrue(results.getSecond().contains(String.format("[F] file:%s/%s",
-                childDirectory.getAbsolutePath(), "file-in-child-directory.tmp")));
-        Assert.assertTrue(results.getSecond().contains(
-                String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp")));
+		pathOne.deleteRecursively();
+	}
 
-        // Clean up
-        directory.deleteRecursively();
-    }
+	@Test
+	public void testDirectoryWithAFile() {
+		final File directory = File.temporaryFolder();
+		directory.child("test.tmp").writeAndClose("test file");
+		final Tuple<List<FileStatus>, List<String>> results = test(directory);
 
-    @Test
-    public void testEmptyDirectory()
-    {
-        final File emptyDirectory = File.temporaryFolder();
-        final Tuple<List<FileStatus>, List<String>> results = test(emptyDirectory);
+		// Verify file statuses
+		Assert.assertFalse(results.getFirst().isEmpty());
+		Assert.assertEquals(1, results.getFirst().size());
 
-        // Verify status and debug strings are empty
-        Assert.assertTrue(results.getFirst().isEmpty());
-        Assert.assertTrue(results.getSecond().isEmpty());
-        emptyDirectory.deleteRecursively();
-    }
+		// Verify debug strings
+		Assert.assertFalse(results.getSecond().isEmpty());
+		Assert.assertEquals(1, results.getSecond().size());
+		Assert.assertEquals(String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp"),
+				results.getSecond().get(0));
+
+		// Clean up
+		directory.deleteRecursively();
+	}
+
+	@Test
+	public void testDirectoryWithAFileInsideAChildDirectory() {
+		final File directory = File.temporaryFolder();
+		directory.child("test.tmp").writeAndClose("test file");
+		final File childDirectory = directory.child("child-directory");
+		Assert.assertTrue(childDirectory.mkdirs());
+		childDirectory.child("file-in-child-directory.tmp").writeAndClose("test child file");
+
+		// Verify file statuses
+		final Tuple<List<FileStatus>, List<String>> results = test(directory);
+		Assert.assertFalse(results.getFirst().isEmpty());
+		Assert.assertEquals(3, results.getFirst().size());
+
+		// Verify debug strings
+		Assert.assertFalse(results.getSecond().isEmpty());
+		Assert.assertEquals(3, results.getSecond().size());
+		Assert.assertTrue(results.getSecond()
+				.contains(String.format("[D] file:%s/%s", directory.getAbsolutePath(), "child-directory")));
+		Assert.assertTrue(results.getSecond().contains(
+				String.format("[F] file:%s/%s", childDirectory.getAbsolutePath(), "file-in-child-directory.tmp")));
+		Assert.assertTrue(
+				results.getSecond().contains(String.format("[F] file:%s/%s", directory.getAbsolutePath(), "test.tmp")));
+
+		// Clean up
+		directory.deleteRecursively();
+	}
+
+	@Test
+	public void testEmptyDirectory() {
+		final File emptyDirectory = File.temporaryFolder();
+		final Tuple<List<FileStatus>, List<String>> results = test(emptyDirectory);
+
+		// Verify status and debug strings are empty
+		Assert.assertTrue(results.getFirst().isEmpty());
+		Assert.assertTrue(results.getSecond().isEmpty());
+		emptyDirectory.deleteRecursively();
+	}
 }


### PR DESCRIPTION
Current implementation of HDFSWalker traverses all the files and directories in the root using breadth first traversal. Limiting this traversal can have an advantage of filtering out unnecessary directory explorations beyond certain depth and gain some performance. This PR addresses the issue and the consumer of this class can limit the file hierarchy exploration beyond certain depth.