### PR TITLE
Add support for binaryFile in SparkInput

### DIFF
--- a/src/test/java/org/openstreetmap/atlas/generator/tools/spark/input/SparkInputTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/spark/input/SparkInputTest.java
@@ -78,6 +78,7 @@ public class SparkInputTest
             {
                 throw new CoreException("Error copying streams", e);
             }
+            // This will be the raw binary version of the contents of the test sequence file
             final String gathered = gatherer.readAndClose();
             logger.info("{}", gathered);
             Assert.assertEquals(181, gatherer.length());

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/spark/input/SparkInputTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/spark/input/SparkInputTest.java
@@ -59,6 +59,7 @@ public class SparkInputTest
     @Test
     public void testBinaryFileReader()
     {
+        // Re-use the same binary file as the one for testing the sequence file
         final JavaPairRDD<String, PortableDataStream> result = SparkInput.binaryFile(this.context,
                 PATH);
         Assert.assertEquals(1L, result.count());


### PR DESCRIPTION
This PR upgrades `SparkInput` to support binary files the same way it supports sequence files.

The only requirement on the underlying file system is to efficiently return the length of a file, as the binary reader cannot infer the length of a file in advance.

See the new test for an example use case.