### PR TITLE
Moving SparkFileHelper and dependencies from atlas-checks to atlas-generator

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/CountrySpecificAtlasFilePathFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/CountrySpecificAtlasFilePathFilter.java
@@ -1,0 +1,36 @@
+package org.openstreetmap.atlas.generator.tools.spark.utilities;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+
+/**
+ * Filters out country-specific {@link Atlas} files given a Hadoop file {@link Path}
+ *
+ * @author mgostintsev
+ */
+public class CountrySpecificAtlasFilePathFilter implements PathFilter
+{
+    private final String country;
+
+    /**
+     * Constructs a filter for given country
+     *
+     * @param country
+     *            country ISO3 code to create filter for
+     */
+    public CountrySpecificAtlasFilePathFilter(final String country)
+    {
+        this.country = country;
+    }
+
+    @Override
+    public boolean accept(final Path path)
+    {
+        return path.getName().contains(this.country)
+                && (path.getName().endsWith(FileSuffix.ATLAS.toString()) || path.getName()
+                        .endsWith(FileSuffix.ATLAS.toString() + FileSuffix.GZIP.toString()));
+    }
+
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
@@ -1,0 +1,526 @@
+package org.openstreetmap.atlas.generator.tools.spark.utilities;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+import java.io.Serializable;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemCreator;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.streaming.resource.WritableResource;
+import org.openstreetmap.atlas.streaming.resource.http.GetResource;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.runtime.Retry;
+import org.openstreetmap.atlas.utilities.scalars.Duration;
+import org.openstreetmap.atlas.utilities.threads.Pool;
+import org.openstreetmap.atlas.utilities.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class for listing and validating the presence of {@link Atlas} files
+ *
+ * @author mgostintsev
+ * @author Sid
+ */
+public class SparkFileHelper implements Serializable
+{
+    // Constants for I/O operations
+    public static final String TEMPORARY_FOLDER_NAME = "_temp";
+    public static final String EMPTY_STRING = "";
+    public static final String DIRECTORY_SEPARATOR = "/";
+    public static final String EXTENSION_SEPARATOR = ".";
+    private static final long serialVersionUID = -5716285735225965942L;
+    private static final Logger logger = LoggerFactory.getLogger(SparkFileHelper.class);
+    private static final Duration MAX_DURATION_FOR_IO = Duration.hours(3);
+    private static final int IO_RETRY_COUNT = 5;
+    private static final Duration WAIT_DURATION_BEFORE_IO_RETRY = Duration.seconds(5);
+    private static Retry IO_RETRY = new Retry(IO_RETRY_COUNT, WAIT_DURATION_BEFORE_IO_RETRY);
+
+    // Spark context useful for read/write from/to different file systems
+    private final Map<String, String> sparkContext;
+
+    /**
+     * Combines given paths
+     *
+     * @param basePath
+     *            a base path
+     * @param paths
+     *            a list of paths
+     * @return the combined path
+     */
+    public static String combine(final String basePath, final String... paths)
+    {
+        final StringBuilder builder = new StringBuilder(pathNotEndingWithSeparator(basePath));
+        for (final String path : paths)
+        {
+            builder.append(DIRECTORY_SEPARATOR);
+            builder.append(pathNotStartingWithSeparator(path));
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * Removes {@code EXTENSION_SEPARATOR} from the beginning of given path
+     *
+     * @param path
+     *            Path to remove {@code EXTENSION_SEPARATOR} from the beginning
+     * @return a path not starting with {@code EXTENSION_SEPARATOR}
+     */
+    public static String extensionStartingWithSeparator(final String path)
+    {
+        return pathStartingWithSeparator(path, EXTENSION_SEPARATOR);
+    }
+
+    /**
+     * Returns parent of given path
+     *
+     * @param path
+     *            a path
+     * @return the parent path
+     */
+    public static String parentPath(final String path)
+    {
+        if (path == null)
+        {
+            logger.warn("Null path. Returning empty path.");
+            return EMPTY_STRING;
+        }
+
+        final int lastSeparatorIndex = path.lastIndexOf(DIRECTORY_SEPARATOR);
+        if (lastSeparatorIndex > 0)
+        {
+            return path.substring(0, lastSeparatorIndex);
+        }
+
+        logger.debug("Given path doesn't have a parent path. Returning the path as is.");
+        return path;
+    }
+
+    /**
+     * Removes {@code PATH_SEPARATOR} from the end of given path
+     *
+     * @param path
+     *            a path
+     * @return a path not ending with {@code PATH_SEPARATOR}
+     */
+    public static String pathNotEndingWithSeparator(final String path)
+    {
+        return pathNotEndingWithSeparator(path, DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Removes {@code PATH_SEPARATOR} from the beginning of given path.
+     *
+     * @param path
+     *            a path
+     * @return a path not beginning with {@code PATH_SEPARATOR}
+     */
+    public static String pathNotStartingWithSeparator(final String path)
+    {
+        return pathNotStartingWithSeparator(path, DIRECTORY_SEPARATOR);
+    }
+
+    private static String pathNotEndingWithSeparator(final String path, final String separator)
+    {
+        if (path == null)
+        {
+            logger.warn("Null path. Returning empty path.");
+            return EMPTY_STRING;
+        }
+
+        if (separator == null)
+        {
+            logger.warn("Null separator. Returning empty path.");
+            return EMPTY_STRING;
+        }
+
+        final int lastSeparatorIndex = path.lastIndexOf(separator);
+        return lastSeparatorIndex == path.length() - 1 ? path.substring(0, lastSeparatorIndex)
+                : path;
+    }
+
+    private static String pathNotStartingWithSeparator(final String path, final String separator)
+    {
+        if (path == null)
+        {
+            logger.warn("Null path. Returning empty path.");
+            return EMPTY_STRING;
+        }
+
+        if (separator == null)
+        {
+            logger.warn("Null separator. Returning empty path.");
+            return EMPTY_STRING;
+        }
+
+        final int firstSeparatorIndex = path.indexOf(separator);
+        return firstSeparatorIndex == 0 ? path.substring(1) : path;
+    }
+
+    private static String pathStartingWithSeparator(final String path, final String separator)
+    {
+        if (path == null)
+        {
+            logger.warn("Null path. Returning empty path.");
+            return EMPTY_STRING;
+        }
+
+        if (separator == null)
+        {
+            logger.warn("Null separator. Returning empty path.");
+            return EMPTY_STRING;
+        }
+
+        final int firstSeparatorIndex = path.indexOf(separator);
+        return firstSeparatorIndex != 0 ? separator + path : path;
+    }
+
+    /**
+     * Constructs a helper with given context
+     *
+     * @param sparkContext
+     *            Spark context as key-value pairs to use as context
+     */
+    public SparkFileHelper(final Map<String, String> sparkContext)
+    {
+        this.sparkContext = sparkContext;
+    }
+
+    /**
+     * Returns a list of Atlas {@link Resource}s for the given country in the supplied directory
+     *
+     * @param directory
+     *            the directory from which to collect the {@link Atlas} files
+     * @param country
+     *            the country, whose {@link Atlas} files we're interested in
+     * @param recursive
+     *            {@code true} to search the given directory and all sub-directories, {@code false}
+     *            to only search the root directory
+     * @return a list of Atlas {@link Resource}s for the given country
+     */
+    public List<Resource> collectAtlasFiles(final String directory, final String country,
+            final boolean recursive)
+    {
+        final CountrySpecificAtlasFilePathFilter filter = new CountrySpecificAtlasFilePathFilter(
+                country);
+        return recursive
+                ? FileSystemHelper.listResourcesRecursively(directory, this.sparkContext, filter)
+                : FileSystemHelper.resources(directory, this.sparkContext, filter);
+    }
+
+    /**
+     * Returns an Atlas {@link Resource} for the given location URI string. The resource is resolve
+     * and returned if the URI points to single resource, not a resource directory, that conforms to
+     * a path defined by at least one of the provided {@link PathFilter}s. The {@link PathFilter}s
+     * provide a way to find well known data types that can be used either directly as or
+     * transformed to an Atlas.
+     *
+     * @param uri
+     *            the location of the Atlas datasource
+     * @param filters
+     *            {@link PathFilter}s used to find datasource types
+     * @return an {@link Atlas} {@link Resource}
+     */
+    public Optional<Resource> collectSourceFile(final String uri, final PathFilter... filters)
+    {
+        final Path path = new Path(uri);
+        Resource resource = null;
+        if (Stream.of(filters).anyMatch(filter -> filter.accept(path)))
+        {
+            final String schema = URI.create(uri).getScheme();
+            if ("http".equals(schema) || "https".equals(schema))
+            {
+                logger.info("Downloading {}", uri);
+                resource = new InputStreamResource(
+                        new BufferedInputStream(new GetResource(uri).read())).withName(uri);
+            }
+            if (resource == null)
+            {
+                logger.info("Loading {}", uri);
+                resource = FileSystemHelper.resource(uri, this.sparkContext);
+            }
+        }
+        return Optional.ofNullable(resource);
+    }
+
+    /**
+     * Returns an list of Atlas {@link Resource}s from the given location URI string. Resources are
+     * resolve and returned that conform to any one of the {@link PathFilter}s. The
+     * {@link PathFilter}s provide a way to find well known data types that can be used either
+     * directly as or transformed to an Atlas.
+     *
+     * @param directory
+     *            a location of the Atlas datasource
+     * @param recursive
+     *            {@code true}, to search the given directory and all sub-directories. {@code false}
+     *            , to only search the root directory
+     * @param filters
+     *            {@link PathFilter}s used to find datasource types
+     * @return an Atlas {@link Resource}
+     */
+    public List<Resource> collectSourceFiles(final String directory, final boolean recursive,
+            final PathFilter... filters)
+    {
+        return Iterables.stream(Iterables.from(filters))
+                .flatMap(filter -> recursive
+                        ? FileSystemHelper.listResourcesRecursively(directory, this.sparkContext,
+                                filter)
+                        : FileSystemHelper.resources(directory, this.sparkContext, filter))
+                .collectToList();
+    }
+
+    /**
+     * Renames the {@link SparkFilePath#temporaryPath} to the {@link SparkFilePath#targetPath},
+     * taking care to avoid producing nested directories.
+     *
+     * @param path
+     *            {@link SparkFilePath} to commit
+     */
+    public void commit(final SparkFilePath path)
+    {
+        try
+        {
+            if (this.isDirectory(path.getTemporaryPath()))
+            {
+                logger.debug("Path {} is a directory. Renaming all the files under.", path);
+                if (!this.exists(path.getTargetPath()))
+                {
+                    logger.debug("Creating {}.", path.getTargetPath());
+                    this.mkdir(path.getTargetPath());
+                }
+
+                this.list(path.getTemporaryPath()).forEach(resource ->
+                {
+                    logger.debug("Renaming {} in {} into {}.", resource.getName(),
+                            path.getTemporaryPath(), path.getTargetPath());
+                    this.rename(
+                            SparkFileHelper.combine(path.getTemporaryPath(), resource.getName()),
+                            SparkFileHelper.combine(path.getTargetPath(), resource.getName()));
+                });
+            }
+            else
+            {
+                logger.debug("Renaming {} to {}.", path.getTemporaryPath(), path.getTargetPath());
+                this.rename(path.getTemporaryPath(), path.getTargetPath());
+            }
+        }
+        catch (final Exception e)
+        {
+            logger.warn("Renaming {} failed!", path, e);
+        }
+    }
+
+    /**
+     * Deletes given directory and all it's child items
+     *
+     * @param path
+     *            a path
+     */
+    public void deleteDirectory(final String path)
+    {
+        if (!FileSystemHelper.delete(path, true, this.sparkContext))
+        {
+            throw new CoreException("Delete directory for {} is failed.", path);
+        }
+    }
+
+    /**
+     * Verifies that the input directory containing {@link Atlas} files contains all the expected
+     * countries
+     *
+     * @param directory
+     *            the directory which contains the {@link Atlas} files
+     * @param expectedCountries
+     *            the expected {@link StringList} of country ISO3 codes
+     * @param recursive
+     *            {@code true} to search the given directory and all sub-directories, {@code false}
+     *            to only search the root directory
+     * @return {@code true} if all expected country ISO3 codes are in the given directory,
+     *         {@code false} otherwise
+     */
+    public boolean directoryContainsExpectedCountryAtlases(final String directory,
+            final StringList expectedCountries, final boolean recursive)
+    {
+        for (final String country : expectedCountries)
+        {
+            final List<Resource> atlases = collectAtlasFiles(directory, country, recursive);
+            if (atlases.isEmpty())
+            {
+                // Fail-fast if we recognize a missing country
+                logger.error("Missing Atlas files for {}!", country);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @param path
+     *            Path to check if it exists or not
+     * @return true if given path exists, otherwise false
+     */
+    public boolean exists(final String path)
+    {
+        try
+        {
+            final FileSystem fileSystem = new FileSystemCreator().get(path, this.sparkContext);
+            return fileSystem.exists(new Path(path));
+        }
+        catch (final Exception e)
+        {
+            throw new CoreException("Unable to check if given path {} is a directory or not.", path,
+                    e);
+        }
+    }
+
+    /**
+     * @param path
+     *            Path to check if it is a directory or not
+     * @return true if given path is directory, otherwise false.
+     */
+    public boolean isDirectory(final String path)
+    {
+        try
+        {
+            final FileSystem fileSystem = new FileSystemCreator().get(path, this.sparkContext);
+            return fileSystem.isDirectory(new Path(path));
+        }
+        catch (final Exception e)
+        {
+            throw new CoreException("Unable to check if given path {} is a directory or not.", path,
+                    e);
+        }
+    }
+
+    /**
+     * @param path
+     *            Path to directory to list {@link Resource}s under.
+     * @return List of {@link Resource}s under given path.
+     */
+    public List<Resource> list(final String path)
+    {
+        return FileSystemHelper.resources(path, this.sparkContext);
+    }
+
+    /**
+     * Creates a directory via given path
+     *
+     * @param path
+     *            a path
+     */
+    public void mkdir(final String path)
+    {
+        if (!FileSystemHelper.mkdir(path, this.sparkContext))
+        {
+            throw new CoreException("Create directory for {} is failed.", path);
+        }
+    }
+
+    /**
+     * Renames a source path to destination path
+     *
+     * @param sourcePath
+     *            source path
+     * @param destinationPath
+     *            destination path
+     */
+    public void rename(final String sourcePath, final String destinationPath)
+    {
+        if (!FileSystemHelper.rename(sourcePath, destinationPath, this.sparkContext))
+        {
+            throw new CoreException("Rename from {} to {} is failed.", sourcePath, destinationPath);
+        }
+    }
+
+    /**
+     * Executes {@code SparkFileOutput#getSaveFunc()} for given {@link SparkFileOutput}s
+     *
+     * @param outputs
+     *            {@link SparkFileOutput}s to execute
+     */
+    public void save(final List<SparkFileOutput> outputs)
+    {
+        // Write results
+        try (Pool writePool = new Pool(outputs.size(), "I/O pool", MAX_DURATION_FOR_IO))
+        {
+            for (final SparkFileOutput output : outputs)
+            {
+                writePool.queue(() ->
+                {
+                    IO_RETRY.run(() ->
+                    {
+                        logger.debug("Writing {}: {}.", output.getOperationName(),
+                                output.getPath().getTemporaryPath());
+
+                        final Time timer = Time.now();
+                        output.getSaveFunction().accept(FileSystemHelper.writableResource(
+                                output.getPath().getTemporaryPath(), this.sparkContext));
+                        logger.debug("{} write took {} ms.", output.getOperationName(),
+                                timer.elapsedSince().asMilliseconds());
+                    });
+                });
+            }
+        }
+        catch (final Exception e)
+        {
+            logger.error("Failed save files.", e);
+        }
+    }
+
+    /**
+     * Executes {@code SparkFileOutput#getSaveFunc()} for given {@link SparkFileOutput}s
+     *
+     * @param outputs
+     *            {@link SparkFileOutput}s to execute
+     */
+    public void save(final SparkFileOutput... outputs)
+    {
+        save(Arrays.asList(outputs));
+    }
+
+    /**
+     * Writes given content into given directory with given filename
+     *
+     * @param directory
+     *            a directory path to write files into
+     * @param filename
+     *            the name of the file
+     * @param content
+     *            file content
+     */
+    public void write(final String directory, final String filename, final String content)
+    {
+        IO_RETRY.run(() ->
+        {
+            final WritableResource resource = FileSystemHelper
+                    .writableResource(combine(directory, filename), this.sparkContext);
+            try (BufferedWriter out = new BufferedWriter(
+                    new OutputStreamWriter(resource.write(), StandardCharsets.UTF_8)))
+            {
+                out.write(content);
+            }
+            catch (final Exception e)
+            {
+                throw new CoreException(
+                        String.format("Could not save into %s.", resource.getName()), e);
+            }
+        });
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileOutput.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileOutput.java
@@ -1,0 +1,137 @@
+package org.openstreetmap.atlas.generator.tools.spark.utilities;
+
+import java.io.Serializable;
+import java.util.function.Consumer;
+
+import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
+import org.openstreetmap.atlas.streaming.resource.WritableResource;
+
+/**
+ * Helper class to hide details of output operations for {@link SparkJob}s
+ *
+ * @author mkalender
+ */
+public final class SparkFileOutput implements Serializable
+{
+    private static final long serialVersionUID = 4719291632105671724L;
+
+    private final Consumer<WritableResource> saveFunction;
+    private final SparkFilePath path;
+    private final String operationName;
+
+    /**
+     * Constructs a {@link SparkFileOutput} from given parameters
+     *
+     * @param saveFunction
+     *            save function that is going to be executed
+     * @param folderPath
+     *            {@link SparkFilePath} with folder paths
+     * @param fileName
+     *            file name
+     * @param extension
+     *            file extension
+     * @param operationName
+     *            name of the output operation
+     * @return a new {@link SparkFileOutput}
+     */
+    public static SparkFileOutput from(final Consumer<WritableResource> saveFunction,
+            final SparkFilePath folderPath, final String fileName, final String extension,
+            final String operationName)
+    {
+        final String fileNameWithExtension = fileName
+                + SparkFileHelper.extensionStartingWithSeparator(extension);
+        final SparkFilePath filePath = new SparkFilePath(
+                SparkFileHelper.combine(folderPath.getTemporaryPath(), fileNameWithExtension),
+                SparkFileHelper.combine(folderPath.getTargetPath(), fileNameWithExtension));
+
+        return new SparkFileOutput(saveFunction, filePath, operationName);
+    }
+
+    /**
+     * Constructs a {@link SparkFileOutput} from given parameters
+     *
+     * @param saveFunction
+     *            save function that is going to be executed
+     * @param parentFolder
+     *            parent folder
+     * @param targetFolder
+     *            target folder
+     * @param folder
+     *            sub-folder
+     * @param fileName
+     *            file name
+     * @param extension
+     *            file extension
+     * @param operationName
+     *            name of the output operation
+     * @return a new {@link SparkFileOutput}
+     */
+    public static SparkFileOutput from(final Consumer<WritableResource> saveFunction,
+            final String parentFolder, final String targetFolder, final String folder,
+            final String fileName, final String extension, final String operationName)
+    {
+        return new SparkFileOutput(saveFunction,
+                getFilePath(targetFolder, parentFolder, folder, fileName, extension),
+                operationName);
+    }
+
+    /**
+     * Calculates file path with given path parameters. System library is not being utilized, since
+     * path is sometimes a local file path, sometimes a URI.
+     *
+     * @param targetFolder
+     *            target folder
+     * @param parentFolder
+     *            parent folder
+     * @param folder
+     *            folder
+     * @param fileName
+     *            file name
+     * @param extension
+     *            file extension
+     * @return a new {@SparkFilePath}
+     */
+    private static SparkFilePath getFilePath(final String targetFolder, final String parentFolder,
+            final String folder, final String fileName, final String extension)
+    {
+        final String fileNameWithFolderAndExtension = SparkFileHelper.combine(folder,
+                fileName + SparkFileHelper.extensionStartingWithSeparator(extension));
+
+        return new SparkFilePath(
+                SparkFileHelper.combine(parentFolder, fileNameWithFolderAndExtension),
+                SparkFileHelper.combine(targetFolder, fileNameWithFolderAndExtension));
+    }
+
+    private SparkFileOutput(final Consumer<WritableResource> saveFunc, final SparkFilePath path,
+            final String operationName)
+    {
+        this.saveFunction = saveFunc;
+        this.path = path;
+        this.operationName = operationName;
+    }
+
+    /**
+     * @return the operation name
+     */
+    public String getOperationName()
+    {
+        return this.operationName;
+    }
+
+    /**
+     * @return the path
+     */
+    public SparkFilePath getPath()
+    {
+        return this.path;
+    }
+
+    /**
+     * @return the save function
+     */
+    public Consumer<WritableResource> getSaveFunction()
+    {
+        return this.saveFunction;
+    }
+
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFilePath.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFilePath.java
@@ -1,0 +1,53 @@
+package org.openstreetmap.atlas.generator.tools.spark.utilities;
+
+import java.io.Serializable;
+
+/**
+ * A helper class to handle temporary and target paths
+ *
+ * @author mkalender
+ */
+public final class SparkFilePath implements Serializable
+{
+    private static final long serialVersionUID = -7976178731336901454L;
+
+    private final String temporaryPath;
+    private final String targetPath;
+
+    /**
+     * Default constructor
+     *
+     * @param temporaryPath
+     *            a temporary file path
+     * @param targetPath
+     *            the target file path
+     */
+    public SparkFilePath(final String temporaryPath, final String targetPath)
+    {
+        this.temporaryPath = temporaryPath;
+        this.targetPath = targetPath;
+    }
+
+    /**
+     * @return the target file path
+     */
+    public String getTargetPath()
+    {
+        return this.targetPath;
+    }
+
+    /**
+     * @return the temporary file path
+     */
+    public String getTemporaryPath()
+    {
+        return this.temporaryPath;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("{target: %s, temporary: %s}", this.getTargetPath(),
+                this.getTemporaryPath());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
@@ -1,0 +1,190 @@
+package org.openstreetmap.atlas.generator.tools.spark.utilities;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+
+import com.google.common.base.Objects;
+import com.google.common.io.Files;
+
+/**
+ * Tests for {@link SparkFileHelper}.
+ *
+ * @author mkalender
+ */
+public class SparkFileHelperTest
+{
+    // A helper without any specific configuration
+    // Empty configuration targets local filesystem
+    private static final SparkFileHelper TEST_HELPER = new SparkFileHelper(Collections.emptyMap());
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testCommitDirectory() throws IOException
+    {
+        // Create temporary files
+        // Delete one and rename one to another
+        final File tempFolder = this.temporaryFolder.newFolder();
+        final File targetFolder = this.temporaryFolder.newFolder();
+
+        targetFolder.delete();
+
+        final File tempFile = File.createTempFile("test", FileSuffix.TEMPORARY.toString(),
+                tempFolder);
+        final File tempFile2 = File.createTempFile("test-another", FileSuffix.TEMPORARY.toString(),
+                tempFolder);
+
+        TEST_HELPER.commit(
+                new SparkFilePath(tempFolder.getAbsolutePath(), targetFolder.getAbsolutePath()));
+
+        Assert.assertFalse(tempFile.exists());
+        Assert.assertFalse(tempFile2.exists());
+
+        final String[] targetFile = targetFolder
+                .list((dir, name) -> name.equals(tempFile.getName()));
+        Assert.assertNotNull(targetFile);
+        Assert.assertEquals(1, targetFile.length);
+
+        final String[] targetFile2 = targetFolder
+                .list((dir, name) -> name.equals(tempFile.getName()));
+        Assert.assertNotNull(targetFile2);
+        Assert.assertEquals(1, targetFile2.length);
+    }
+
+    @Test
+    public void testCommitFile() throws IOException
+    {
+        // Create temporary files
+        // Delete one and rename one to another
+        final File tempFile = File.createTempFile("test", FileSuffix.TEMPORARY.toString());
+        tempFile.deleteOnExit();
+        Assert.assertTrue(tempFile.exists());
+
+        final File tempFile2 = File.createTempFile("test-another", FileSuffix.TEMPORARY.toString());
+        tempFile2.delete();
+        Assert.assertFalse(tempFile2.exists());
+
+        // Rename test to test-another
+        TEST_HELPER
+                .commit(new SparkFilePath(tempFile.getAbsolutePath(), tempFile2.getAbsolutePath()));
+        Assert.assertFalse(tempFile.exists());
+        Assert.assertTrue(tempFile2.exists());
+    }
+
+    @Test(expected = CoreException.class)
+    public void testDeleteNonExistingDirectory()
+    {
+        // Generate a temp path
+        final File tempFolder = Files.createTempDir();
+        final String path = tempFolder.getAbsolutePath();
+        tempFolder.delete();
+
+        // Try to delete directory
+        TEST_HELPER.deleteDirectory(path);
+    }
+
+    @Test
+    public void testIsDirectory() throws IOException
+    {
+        // Test a file
+        final File tempFile = File.createTempFile("test", FileSuffix.TEMPORARY.toString());
+        tempFile.deleteOnExit();
+        Assert.assertFalse(TEST_HELPER.isDirectory(tempFile.getAbsolutePath()));
+
+        // Test a folder
+        final File tempFolder = Files.createTempDir();
+        tempFolder.deleteOnExit();
+        Assert.assertTrue(TEST_HELPER.isDirectory(tempFolder.getAbsolutePath()));
+    }
+
+    @Test
+    public void testList() throws IOException
+    {
+        // Start with an empty folder
+        final File tempFolder = Files.createTempDir();
+        tempFolder.deleteOnExit();
+        Assert.assertTrue(TEST_HELPER.list(tempFolder.getAbsolutePath()).isEmpty());
+
+        // Add a file and then delete
+        final File tempFile1 = File.createTempFile("test1", FileSuffix.TEMPORARY.toString(),
+                tempFolder);
+        Assert.assertEquals(1, TEST_HELPER.list(tempFolder.getAbsolutePath()).size());
+        tempFile1.delete();
+        Assert.assertTrue(TEST_HELPER.list(tempFolder.getAbsolutePath()).isEmpty());
+
+        // Generate random number of files
+        final int randomFileCount = new Random().nextInt(50) + 1;
+        final File[] randomFiles = new File[randomFileCount];
+        for (int index = 0; index < randomFileCount; index++)
+        {
+            randomFiles[index] = File.createTempFile("test" + index,
+                    FileSuffix.TEMPORARY.toString(), tempFolder);
+            Assert.assertEquals(index + 1, TEST_HELPER.list(tempFolder.getAbsolutePath()).size());
+        }
+
+        Assert.assertEquals(randomFileCount, TEST_HELPER.list(tempFolder.getAbsolutePath()).size());
+
+        // Go over and make sure files are there
+        final List<Resource> files = TEST_HELPER.list(tempFolder.getAbsolutePath());
+        for (final File randomFile : randomFiles)
+        {
+            Assert.assertTrue(
+                    files.stream().anyMatch(resource -> Objects.equal(randomFile.getPath(),
+                            SparkFileHelper.combine(tempFolder.getPath(), resource.getName()))));
+        }
+    }
+
+    @Test
+    public void testMkdirAndDeleteDirectory()
+    {
+        // Generate a temp path
+        final File tempFolder = Files.createTempDir();
+        final String path = tempFolder.getAbsolutePath();
+        tempFolder.delete();
+
+        // Make sure folder doesn't exist yet
+        Assert.assertFalse(TEST_HELPER.isDirectory(path));
+        Assert.assertFalse(new File(path).exists());
+
+        // Create directory
+        TEST_HELPER.mkdir(path);
+        Assert.assertTrue(TEST_HELPER.isDirectory(path));
+        Assert.assertTrue(new File(path).exists());
+
+        // Delete directory
+        TEST_HELPER.deleteDirectory(path);
+        Assert.assertFalse(TEST_HELPER.isDirectory(path));
+        Assert.assertFalse(new File(path).exists());
+    }
+
+    @Test
+    public void testRename() throws IOException
+    {
+        // Create temporary files
+        // Delete one and rename one to another
+        final File tempFile = File.createTempFile("test", FileSuffix.TEMPORARY.toString());
+        tempFile.deleteOnExit();
+        Assert.assertTrue(tempFile.exists());
+
+        final File tempFile2 = File.createTempFile("test-another", FileSuffix.TEMPORARY.toString());
+        tempFile2.delete();
+        Assert.assertFalse(tempFile2.exists());
+
+        // Rename test to test-another
+        TEST_HELPER.rename(tempFile.getAbsolutePath(), tempFile2.getAbsolutePath());
+        Assert.assertFalse(tempFile.exists());
+        Assert.assertTrue(tempFile2.exists());
+    }
+}


### PR DESCRIPTION
SparkFileHelper and dependencies is currently found in [atlas-checks](https://github.com/osmlab/atlas-checks/tree/dev/src/main/java/org/openstreetmap/atlas/checks/persistence). It is a set of utilities that simplifies Hadoop FileSystem interactions with atlas files.

Based on that, the right home for these files is within atlas-generator. After this has been merged, I'll propose a corresponding PR in atlas-checks to update the dependency and remove the files.