### PR TITLE
Move country-shard generation to Spark master

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerationTask.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerationTask.java
@@ -1,0 +1,62 @@
+package org.openstreetmap.atlas.generator;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.geography.sharding.Shard;
+
+/**
+ * Class to encapsulate required artifacts, information for Atlas generation process.
+ *
+ * @author mkalender
+ */
+final class AtlasGenerationTask implements Serializable
+{
+    private static final long serialVersionUID = -3730018742291904849L;
+
+    private final String country;
+    private final Shard shard;
+    private final List<Shard> allShards;
+
+    /**
+     * Default constructor
+     *
+     * @param country
+     *            Country name that Atlas generation will be executed for
+     * @param shard
+     *            {@link Shard} that Atlas generation will be executed for
+     * @param allShards
+     *            All {@link Shard}s for country
+     */
+    AtlasGenerationTask(final String country, final Shard shard, final List<Shard> allShards)
+    {
+        this.country = country;
+        this.shard = shard;
+        this.allShards = allShards;
+    }
+
+    List<Shard> getAllShards()
+    {
+        return this.allShards;
+    }
+
+    String getCountry()
+    {
+        return this.country;
+    }
+
+    Shard getShard()
+    {
+        return this.shard;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s - %s:%s%s", this.getCountry(), this.getShard(),
+                System.lineSeparator(),
+                this.getAllShards().stream().map(shard -> String.format(" - %s", shard))
+                        .collect(Collectors.joining(System.lineSeparator())));
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerationTask.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerationTask.java
@@ -1,7 +1,7 @@
 package org.openstreetmap.atlas.generator;
 
 import java.io.Serializable;
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.geography.sharding.Shard;
@@ -17,7 +17,7 @@ final class AtlasGenerationTask implements Serializable
 
     private final String country;
     private final Shard shard;
-    private final List<Shard> allShards;
+    private final Set<Shard> allShards;
 
     /**
      * Default constructor
@@ -29,14 +29,14 @@ final class AtlasGenerationTask implements Serializable
      * @param allShards
      *            All {@link Shard}s for country
      */
-    AtlasGenerationTask(final String country, final Shard shard, final List<Shard> allShards)
+    AtlasGenerationTask(final String country, final Shard shard, final Set<Shard> allShards)
     {
         this.country = country;
         this.shard = shard;
         this.allShards = allShards;
     }
 
-    List<Shard> getAllShards()
+    Set<Shard> getAllShards()
     {
         return this.allShards;
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -3,7 +3,6 @@ package org.openstreetmap.atlas.generator;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +42,7 @@ import org.openstreetmap.atlas.tags.filters.ConfiguredTaggableFilter;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
 import org.openstreetmap.atlas.utilities.conversion.StringConverter;
+import org.openstreetmap.atlas.utilities.maps.MultiMapWithSet;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
 import org.openstreetmap.atlas.utilities.runtime.system.memory.Memory;
 import org.openstreetmap.atlas.utilities.threads.Pool;
@@ -149,7 +149,7 @@ public class AtlasGenerator extends SparkJob
     {
         // Extract country boundaries and queue them
         final BlockingQueue<CountryBoundary> queue = new LinkedBlockingQueue<>();
-        final Map<String, Set<Shard>> countryToShardMap = new HashMap<>();
+        final MultiMapWithSet<String, Shard> countryToShardMap = new MultiMapWithSet<>();
         countries.stream().forEach(country ->
         {
             // Initialize country-shard map

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -3,11 +3,9 @@ package org.openstreetmap.atlas.generator;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -16,15 +14,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.spark.api.java.JavaPairRDD;
-import org.apache.spark.api.java.JavaRDD;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasStatisticsOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.delta.RemovedMultipleAtlasDeltaOutputFormat;
 import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
-import org.openstreetmap.atlas.geography.MultiPolygon;
-import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
@@ -39,7 +34,6 @@ import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.tags.filters.ConfiguredTaggableFilter;
-import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
 import org.openstreetmap.atlas.utilities.conversion.StringConverter;
@@ -58,6 +52,7 @@ import scala.Tuple2;
  */
 public class AtlasGenerator extends SparkJob
 {
+
     /**
      * @author matthieun
      */
@@ -131,65 +126,58 @@ public class AtlasGenerator extends SparkJob
     }
 
     /**
-     * @param shard
-     *            The {@link Shard} to test
-     * @param boundaries
-     *            The set of country boundaries to test the shard with
-     * @return {@code true} when the shard partially or fully intersects at least one of the country
-     *         boundaries in the set.
-     */
-    protected static boolean filterShards(final Shard shard, final List<CountryBoundary> boundaries)
-    {
-        boolean result = false;
-        for (final CountryBoundary boundary : boundaries)
-        {
-            final MultiPolygon boundaryShape = boundary.getBoundary();
-            for (final Polygon outer : boundaryShape.outers())
-            {
-                if (outer.overlaps(shard.bounds()))
-                {
-                    result = true;
-                    for (final Polygon inner : boundaryShape.innersOf(outer))
-                    {
-                        if (inner.fullyGeometricallyEncloses(shard.bounds()))
-                        {
-                            result = false;
-                            break;
-                        }
-                    }
-                    if (result)
-                    {
-                        break;
-                    }
-                }
-            }
-            if (result)
-            {
-                break;
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Get a rough idea of all the shards for a specific country, by using the country's bounds to
-     * find all the shards. It some cases, this list will contain a lot of false positives.
+     * Generates a {@link List} of {@link AtlasGenerationTask}s for given countries using given
+     * {@link CountryBoundaryMap} and {@link Sharding} strategy.
      *
+     * @param countries
+     *            Countries to generate tasks for
+     * @param boundaryMap
+     *            {@link CountryBoundaryMap} to read country boundaries
      * @param sharding
-     *            The sharding tree to consider
-     * @param countryBoundary
-     *            The country boundary for which to find the shards
-     * @return The rough tally of shards
+     *            {@link Sharding} strategy
+     * @return {@link List} of {@link AtlasGenerationTask}s
      */
-    protected static Set<Shard> roughShards(final Sharding sharding,
-            final CountryBoundary countryBoundary)
+    protected static List<AtlasGenerationTask> generateTasks(final StringList countries,
+            final CountryBoundaryMap boundaryMap, final Sharding sharding)
     {
-        final Set<Shard> shards = new HashSet<>();
-        for (final Polygon subBoundary : countryBoundary.getBoundary().outers())
+        // First create country-shard map
+        final MultiMap<String, Shard> countryToShardMap = new MultiMap<>();
+        countries.stream().forEach(country ->
         {
-            sharding.shards(subBoundary.bounds()).forEach(shards::add);
-        }
-        return shards;
+            // Fetch boundaries
+            final List<CountryBoundary> countryBoundaries = boundaryMap.countryBoundary(country);
+            if (countryBoundaries == null)
+            {
+                logger.error("No boundaries found for {}!", country);
+                return;
+            }
+
+            // Extract shards
+            countryBoundaries.forEach(countryBoundary ->
+            {
+                sharding.shards(countryBoundary.getBoundary()).forEach(shard ->
+                {
+                    countryToShardMap.add(country, shard);
+                });
+            });
+        });
+
+        // Generate tasks from country-shard map
+        final List<AtlasGenerationTask> tasks = new ArrayList<>();
+        countryToShardMap.keySet().forEach(country ->
+        {
+            final List<Shard> shards = countryToShardMap.get(country);
+            if (!shards.isEmpty())
+            {
+                shards.forEach(shard -> tasks.add(new AtlasGenerationTask(country, shard, shards)));
+            }
+            else
+            {
+                logger.warn("No shards were found for {}. Skipping task generation.", country);
+            }
+        });
+
+        return tasks;
     }
 
     private static ConfiguredTaggableFilter getTaggableFilterFrom(final String path,
@@ -271,133 +259,80 @@ public class AtlasGenerator extends SparkJob
             worldBoundaries.initializeGridIndex(countries.stream().collect(Collectors.toSet()));
         }
 
-        // ****** SPARK CODE BELOW ****** //
-
-        // The code below is as parallel as there are countries...
-        final JavaRDD<String> countriesRDD = getContext().parallelize(Iterables.asList(countries),
-                countries.size());
-
-        // Get a list of country shard pairs, with a lot of false positives
-        // TODO Leverage country boundary map grid index when ready
-        final List<Tuple2<String, Shard>> roughCountryShards = countriesRDD
-                .flatMapToPair(countryName ->
-                {
-                    // For each country boundary
-                    final List<CountryBoundary> boundaries = worldBoundaries
-                            .countryBoundary(countryName);
-
-                    // Handle missing boundaries case
-                    if (boundaries == null)
-                    {
-                        logger.error("No boundaries found for country {}!", countryName);
-                        return new ArrayList<>();
-                    }
-
-                    logger.info("Generating shards for country {}", countryName);
-                    final Set<Shard> shards = new HashSet<>();
-                    for (final CountryBoundary boundary : boundaries)
-                    {
-                        // Identify all the shards in the country's bounding box and filter out
-                        // those that do not intersect
-                        shards.addAll(roughShards(sharding, boundary));
-                    }
-                    // Assign the country name / shard couples to the countryShards list to be
-                    // parallelized
-                    final List<Tuple2<String, Shard>> countryShards = new ArrayList<>();
-                    shards.forEach(shard -> countryShards.add(new Tuple2<>(countryName, shard)));
-                    return countryShards;
-                }).collect();
-
-        // Get a RDD of country shards without any false positives
-        // TODO Leverage country boundary map grid index when ready
-        final JavaPairRDD<String, Shard> preCountryShardsRDD = getContext()
-                .parallelizePairs(roughCountryShards, roughCountryShards.size()).filter(tuple ->
-                {
-                    final String countryName = tuple._1();
-                    final Shard shard = tuple._2();
-                    final List<CountryBoundary> boundaries = worldBoundaries
-                            .countryBoundary(countryName);
-                    return filterShards(shard, boundaries);
-                });
-
-        // Collect and re-parallelize so the code below is as parallel as there are countries/shard
-        // pairs (many more!)...
-        final List<Tuple2<String, Shard>> countryShards = preCountryShardsRDD.collect();
-        // Keep it as a MultiMap to pass it to the Atlas meta data.
-        final MultiMap<String, Shard> countryToShardMap = new MultiMap<>();
-        countryShards.forEach(tuple -> countryToShardMap.add(tuple._1(), tuple._2()));
-        final JavaPairRDD<String, Shard> countryShardsRDD = getContext()
-                .parallelizePairs(countryShards, countryShards.size());
+        // Extract country shard tuples
+        final List<AtlasGenerationTask> tasks = generateTasks(countries, worldBoundaries, sharding);
 
         // Transform the map country name to shard to country name to Atlas
         // This is not enforced, but it has to be a 1-1 mapping here.
         final Map<String, String> configurationMap = configurationMap();
-        final JavaPairRDD<String, Atlas> countryAtlasShardsRDD = countryShardsRDD.mapToPair(tuple ->
-        {
-            // Get the country name
-            final String countryName = tuple._1();
-            // Get the country shard
-            final Shard shard = tuple._2();
-            // Build the AtlasLoadingOption
-            final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption
-                    .createOptionWithAllEnabled(worldBoundaries)
-                    .setAdditionalCountryCodes(countryName);
-            // Create a local hadoop configuration to avoid serializing the whole class
-            final Configuration hadoopConfiguration = new Configuration();
-            configurationMap.entrySet()
-                    .forEach(entry -> hadoopConfiguration.set(entry.getKey(), entry.getValue()));
+        final JavaPairRDD<String, Atlas> countryAtlasShardsRDD = getContext().parallelize(tasks)
+                .mapToPair(task ->
+                {
+                    // Get the country name
+                    final String countryName = task.getCountry();
+                    // Get the country shard
+                    final Shard shard = task.getShard();
+                    // Build the AtlasLoadingOption
+                    final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption
+                            .createOptionWithAllEnabled(worldBoundaries)
+                            .setAdditionalCountryCodes(countryName);
+                    // Create a local hadoop configuration to avoid serializing the whole class
+                    final Configuration hadoopConfiguration = new Configuration();
+                    configurationMap.entrySet().forEach(
+                            entry -> hadoopConfiguration.set(entry.getKey(), entry.getValue()));
 
-            // Apply all configurations
-            if (edgeConfiguration != null)
-            {
-                atlasLoadingOption.setEdgeFilter(
-                        getTaggableFilterFrom(edgeConfiguration, hadoopConfiguration));
-            }
-            if (waySectioningConfiguration != null)
-            {
-                atlasLoadingOption.setWaySectionFilter(
-                        getTaggableFilterFrom(waySectioningConfiguration, hadoopConfiguration));
-            }
-            if (pbfNodeConfiguration != null)
-            {
-                atlasLoadingOption.setOsmPbfNodeFilter(
-                        getTaggableFilterFrom(pbfNodeConfiguration, hadoopConfiguration));
-            }
-            if (pbfWayConfiguration != null)
-            {
-                atlasLoadingOption.setOsmPbfWayFilter(
-                        getTaggableFilterFrom(pbfWayConfiguration, hadoopConfiguration));
-            }
-            if (pbfRelationConfiguration != null)
-            {
-                atlasLoadingOption.setOsmPbfRelationFilter(
-                        getTaggableFilterFrom(pbfRelationConfiguration, hadoopConfiguration));
-            }
+                    // Apply all configurations
+                    if (edgeConfiguration != null)
+                    {
+                        atlasLoadingOption.setEdgeFilter(
+                                getTaggableFilterFrom(edgeConfiguration, hadoopConfiguration));
+                    }
+                    if (waySectioningConfiguration != null)
+                    {
+                        atlasLoadingOption.setWaySectionFilter(getTaggableFilterFrom(
+                                waySectioningConfiguration, hadoopConfiguration));
+                    }
+                    if (pbfNodeConfiguration != null)
+                    {
+                        atlasLoadingOption.setOsmPbfNodeFilter(
+                                getTaggableFilterFrom(pbfNodeConfiguration, hadoopConfiguration));
+                    }
+                    if (pbfWayConfiguration != null)
+                    {
+                        atlasLoadingOption.setOsmPbfWayFilter(
+                                getTaggableFilterFrom(pbfWayConfiguration, hadoopConfiguration));
+                    }
+                    if (pbfRelationConfiguration != null)
+                    {
+                        atlasLoadingOption.setOsmPbfRelationFilter(getTaggableFilterFrom(
+                                pbfRelationConfiguration, hadoopConfiguration));
+                    }
 
-            // Build the appropriate PbfLoader
-            final PbfContext pbfContext = new PbfContext(pbfPath, sharding);
-            final PbfLoader loader = new PbfLoader(pbfContext, sparkContext, worldBoundaries,
-                    atlasLoadingOption, codeVersion, dataVersion, countryToShardMap);
-            final String name = countryName + CountryShard.COUNTRY_SHARD_SEPARATOR
-                    + shard.getName();
-            final Atlas atlas;
-            try
-            {
-                // Generate the Atlas for this shard
-                atlas = loader.load(countryName, shard);
-            }
-            catch (final Throwable e)
-            {
-                throw new CoreException("Building Atlas {} failed!", name, e);
-            }
+                    // Build the appropriate PbfLoader
+                    final PbfContext pbfContext = new PbfContext(pbfPath, sharding);
+                    final PbfLoader loader = new PbfLoader(pbfContext, sparkContext,
+                            worldBoundaries, atlasLoadingOption, codeVersion, dataVersion,
+                            task.getAllShards());
+                    final String name = countryName + CountryShard.COUNTRY_SHARD_SEPARATOR
+                            + shard.getName();
+                    final Atlas atlas;
+                    try
+                    {
+                        // Generate the Atlas for this shard
+                        atlas = loader.load(countryName, shard);
+                    }
+                    catch (final Throwable e)
+                    {
+                        throw new CoreException("Building Atlas {} failed!", name, e);
+                    }
 
-            // Report on memory usage
-            logger.info("Printing memory after loading Atlas {}", name);
-            Memory.printCurrentMemory();
-            // Output the Name/Atlas couple
-            final Tuple2<String, Atlas> result = new Tuple2<>(name, atlas);
-            return result;
-        });
+                    // Report on memory usage
+                    logger.info("Printing memory after loading Atlas {}", name);
+                    Memory.printCurrentMemory();
+                    // Output the Name/Atlas couple
+                    final Tuple2<String, Atlas> result = new Tuple2<>(name, atlas);
+                    return result;
+                });
 
         // Filter out null Atlas.
         final JavaPairRDD<String, Atlas> countryNonNullAtlasShardsRDD = countryAtlasShardsRDD

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorTaskProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorTaskProcessor.java
@@ -1,0 +1,92 @@
+package org.openstreetmap.atlas.generator;
+
+import java.util.concurrent.BlockingQueue;
+
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.boundary.CountryBoundary;
+import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.Sharding;
+import org.openstreetmap.atlas.utilities.maps.MultiMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Worker that acts like both producer and consumer. Takes an {@link CountryBoundary} from work
+ * queue and processes it.
+ *
+ * @author mkalender
+ */
+class AtlasGeneratorTaskProcessor implements Runnable
+{
+    private static final Logger logger = LoggerFactory.getLogger(AtlasGeneratorTaskProcessor.class);
+    private final BlockingQueue<CountryBoundary> queue;
+    private final Sharding sharding;
+    private final CountryBoundaryMap boundaryMap;
+    private final MultiMap<String, Shard> countryToShardMap;
+
+    /**
+     * Default constructor.
+     *
+     * @param queue
+     *            {@link BlockingQueue} holding {@link CountryBoundary}s to process
+     * @param sharding
+     *            {@link Sharding} strategy to extract {@link Shard}s
+     * @param boundaryMap
+     *            {@link CountryBoundaryMap} to eliminate false positives
+     * @param countryToShardMap
+     *            {@link Map} of country names to {@link List} of {@link Shard}s
+     */
+    AtlasGeneratorTaskProcessor(final BlockingQueue<CountryBoundary> queue, final Sharding sharding,
+            final CountryBoundaryMap boundaryMap, final MultiMap<String, Shard> countryToShardMap)
+    {
+        this.queue = queue;
+        this.sharding = sharding;
+        this.boundaryMap = boundaryMap;
+        this.countryToShardMap = countryToShardMap;
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            while (!this.queue.isEmpty())
+            {
+                final CountryBoundary itemToProcess = this.queue.poll();
+
+                // Queue might have been emptied by another thread. That gives an null item.
+                // Check for null item to avoid an exception.
+                if (itemToProcess != null)
+                {
+                    this.process(itemToProcess);
+                }
+            }
+        }
+        catch (final Exception e)
+        {
+            logger.error("Processor failed to process.", e);
+        }
+    }
+
+    private void process(final CountryBoundary item)
+    {
+        this.sharding.shards(item.getBoundary().bounds()).forEach(shard ->
+        {
+            final String country = item.getCountryName();
+
+            // Skip a shard if
+            // - there is no corresponding grid for given country
+            // - or given country boundary doesn't overlap with shard bounds
+            final Rectangle shardBounds = shard.bounds();
+            if (this.boundaryMap.countryCodesOverlappingWith(shardBounds).contains(country)
+                    && item.getBoundary().overlaps(shardBounds))
+            {
+                synchronized (this.countryToShardMap)
+                {
+                    this.countryToShardMap.add(country, shard);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorTaskProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorTaskProcessor.java
@@ -9,6 +9,7 @@ import org.openstreetmap.atlas.geography.boundary.CountryBoundary;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
+import org.openstreetmap.atlas.utilities.maps.MultiMapWithSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,7 +25,7 @@ class AtlasGeneratorTaskProcessor implements Runnable
     private final BlockingQueue<CountryBoundary> queue;
     private final Sharding sharding;
     private final CountryBoundaryMap boundaryMap;
-    private final Map<String, Set<Shard>> countryToShardMap;
+    private final MultiMapWithSet<String, Shard> countryToShardMap;
 
     /**
      * Default constructor.
@@ -36,10 +37,11 @@ class AtlasGeneratorTaskProcessor implements Runnable
      * @param boundaryMap
      *            {@link CountryBoundaryMap} to eliminate false positives
      * @param countryToShardMap
-     *            {@link Map} of country names to {@link List} of {@link Shard}s
+     *            {@link Map} of country names to {@link Set} of {@link Shard}s
      */
     AtlasGeneratorTaskProcessor(final BlockingQueue<CountryBoundary> queue, final Sharding sharding,
-            final CountryBoundaryMap boundaryMap, final Map<String, Set<Shard>> countryToShardMap)
+            final CountryBoundaryMap boundaryMap,
+            final MultiMapWithSet<String, Shard> countryToShardMap)
     {
         this.queue = queue;
         this.sharding = sharding;

--- a/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.generator.PbfLocator.LocatedPbf;
@@ -45,7 +46,7 @@ public class PbfLoader implements Serializable
     private final AtlasLoadingOption atlasLoadingOption;
     private final String codeVersion;
     private final String dataVersion;
-    private final List<Shard> countryShards;
+    private final Set<Shard> countryShards;
 
     public static void setAtlasSaveFolder(final File atlasSaveFolder)
     {
@@ -68,11 +69,11 @@ public class PbfLoader implements Serializable
      * @param dataVersion
      *            The version of the data in the PBFs
      * @param countryShards
-     *            List of {@link Shard}s for the Atlas meta data
+     *            {@link Set} of {@link Shard}s for the Atlas meta data
      */
     public PbfLoader(final PbfContext pbfContext, final Map<String, String> sparkContext,
             final CountryBoundaryMap boundaries, final AtlasLoadingOption atlasLoadingOption,
-            final String codeVersion, final String dataVersion, final List<Shard> countryShards)
+            final String codeVersion, final String dataVersion, final Set<Shard> countryShards)
     {
         this.boundaries = boundaries;
         this.atlasLoadingOption = atlasLoadingOption;

--- a/src/main/java/org/openstreetmap/atlas/generator/creator/AtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/creator/AtlasCreator.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.generator.creator;
 
+import java.util.Collections;
 import java.util.HashMap;
 
 import org.openstreetmap.atlas.generator.AtlasGenerator;
@@ -15,7 +16,6 @@ import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.conversion.StringConverter;
-import org.openstreetmap.atlas.utilities.maps.MultiMap;
 import org.openstreetmap.atlas.utilities.runtime.Command;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
 
@@ -54,10 +54,11 @@ public class AtlasCreator extends Command
     public Atlas generateAtlas(final CountryBoundaryMap map, final Shard tile, final String pbfPath,
             final Sharding sharding, final String countryName)
     {
-        final PbfLoader loader = new PbfLoader(new PbfContext(pbfPath, sharding),
-                new HashMap<>(), map, AtlasLoadingOption.createOptionWithAllEnabled(map)
+        final PbfLoader loader = new PbfLoader(new PbfContext(pbfPath, sharding), new HashMap<>(),
+                map,
+                AtlasLoadingOption.createOptionWithAllEnabled(map)
                         .setAdditionalCountryCodes(countryName),
-                "dummyCodeVersion", "dummyDataVersion", new MultiMap<>());
+                "dummyCodeVersion", "dummyDataVersion", Collections.emptyList());
         return loader.load(countryName, tile);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/generator/creator/AtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/creator/AtlasCreator.java
@@ -58,7 +58,7 @@ public class AtlasCreator extends Command
                 map,
                 AtlasLoadingOption.createOptionWithAllEnabled(map)
                         .setAdditionalCountryCodes(countryName),
-                "dummyCodeVersion", "dummyDataVersion", Collections.emptyList());
+                "dummyCodeVersion", "dummyDataVersion", Collections.emptySet());
         return loader.load(countryName, tile);
     }
 

--- a/src/test/java/org/openstreetmap/atlas/generator/AtlasGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/AtlasGeneratorTest.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.generator;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -88,7 +89,7 @@ public class AtlasGeneratorTest
     private void verifyAllShardEquality(final List<AtlasGenerationTask> tasks)
     {
         final String referenceCountry = tasks.get(0).getCountry();
-        final List<Shard> referenceShards = tasks.get(0).getAllShards();
+        final Set<Shard> referenceShards = tasks.get(0).getAllShards();
         tasks.stream().skip(1).forEach(otherTask ->
         {
             Assert.assertEquals(referenceCountry, otherTask.getCountry());
@@ -98,9 +99,9 @@ public class AtlasGeneratorTest
 
     private void verifyNoShardIsMissing(final List<AtlasGenerationTask> tasks)
     {
-        final List<Shard> referenceShards = tasks.get(0).getAllShards();
-        final List<Shard> taskShards = tasks.stream().map(task -> task.getShard())
-                .collect(Collectors.toList());
+        final Set<Shard> referenceShards = tasks.get(0).getAllShards();
+        final Set<Shard> taskShards = tasks.stream().map(task -> task.getShard())
+                .collect(Collectors.toSet());
         Assert.assertEquals(referenceShards, taskShards);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/generator/AtlasGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/AtlasGeneratorTest.java
@@ -1,57 +1,106 @@
 package org.openstreetmap.atlas.generator;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openstreetmap.atlas.geography.boundary.CountryBoundary;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.geography.sharding.DynamicTileSharding;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
-import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.utilities.collections.StringList;
 
 /**
+ * Tests for {@link AtlasGenerator}.
+ *
  * @author matthieun
+ * @author mkalender
  */
 public class AtlasGeneratorTest
 {
+    private static final Sharding SHARDING = new DynamicTileSharding(new InputStreamResource(
+            () -> AtlasGenerator.class.getResourceAsStream("tree-6-14-100000.txt")));
+    private static final CountryBoundaryMap HTI_BOUNDARY_MAP = CountryBoundaryMap.fromPlainText(
+            new InputStreamResource(() -> AtlasGeneratorTest.class.getResourceAsStream("HTI.txt")));
+    private static final CountryBoundaryMap JAM_BOUNDARY_MAP = CountryBoundaryMap.fromPlainText(
+            new InputStreamResource(() -> AtlasGeneratorTest.class.getResourceAsStream("JAM.txt")));
+
     @Test
-    public void testRoughFilterShards()
+    public void testGenerateTasksEmptyBoundary()
     {
-        final CountryBoundaryMap countryBoundaryMapHTI = CountryBoundaryMap
-                .fromPlainText(new InputStreamResource(
-                        () -> AtlasGeneratorTest.class.getResourceAsStream("HTI.txt")));
-        final CountryBoundaryMap countryBoundaryMapJAM = CountryBoundaryMap
-                .fromPlainText(new InputStreamResource(
-                        () -> AtlasGeneratorTest.class.getResourceAsStream("JAM.txt")));
+        final CountryBoundaryMap boundaryMap = new CountryBoundaryMap();
+        Assert.assertTrue(AtlasGenerator.generateTasks(new StringList("HTI"), boundaryMap, SHARDING)
+                .isEmpty());
+    }
 
-        final List<CountryBoundary> countryBoundaryHTI = countryBoundaryMapHTI
-                .countryBoundary("HTI");
-        final List<CountryBoundary> countryBoundaryJAM = countryBoundaryMapJAM
-                .countryBoundary("JAM");
+    @Test
+    public void testGenerateTasksEmptyBoundaryAndCountryList()
+    {
+        final CountryBoundaryMap boundaryMap = new CountryBoundaryMap();
+        Assert.assertTrue(
+                AtlasGenerator.generateTasks(new StringList(), boundaryMap, SHARDING).isEmpty());
+    }
 
-        final Sharding sharding = new DynamicTileSharding(new InputStreamResource(
-                () -> AtlasGenerator.class.getResourceAsStream("tree-6-14-100000.txt")));
+    @Test
+    public void testGenerateTasksEmptyCountryList()
+    {
+        Assert.assertTrue(AtlasGenerator.generateTasks(new StringList(), HTI_BOUNDARY_MAP, SHARDING)
+                .isEmpty());
+    }
 
-        final Set<Shard> shardsHTI = AtlasGenerator.roughShards(sharding,
-                countryBoundaryHTI.get(0));
-        final Set<Shard> filteredOutHTI = shardsHTI.stream()
-                .filter(shard -> !AtlasGenerator.filterShards(shard, countryBoundaryHTI))
-                .collect(Collectors.toSet());
-        Assert.assertEquals(2, filteredOutHTI.size());
-        Assert.assertTrue(filteredOutHTI.contains(new SlippyTile(74, 115, 8)));
-        Assert.assertTrue(filteredOutHTI.contains(new SlippyTile(77, 115, 8)));
+    @Test
+    public void testGenerateTasksHTI()
+    {
+        // HTI boundary should have generated 36 tasks
+        testCountry(new StringList("HTI"), HTI_BOUNDARY_MAP, 36);
+    }
 
-        final Set<Shard> shardsJAM = AtlasGenerator.roughShards(sharding,
-                countryBoundaryJAM.get(0));
-        final Set<Shard> filteredOutJAM = shardsJAM.stream()
-                .filter(shard -> !AtlasGenerator.filterShards(shard, countryBoundaryJAM))
-                .collect(Collectors.toSet());
-        Assert.assertEquals(1, filteredOutJAM.size());
-        Assert.assertTrue(filteredOutJAM.contains(new SlippyTile(74, 114, 8)));
+    @Test
+    public void testGenerateTasksJAM()
+    {
+        // JAM boundary should have generated 6 tasks
+        testCountry(new StringList("JAM"), JAM_BOUNDARY_MAP, 6);
+    }
+
+    @Test
+    public void testGenerateTasksWrongCountryList()
+    {
+        Assert.assertTrue(AtlasGenerator
+                .generateTasks(new StringList("ABC", "XYZ"), JAM_BOUNDARY_MAP, SHARDING).isEmpty());
+    }
+
+    private void testCountry(final StringList countries, final CountryBoundaryMap boundaryMap,
+            final int expectedTaskSize)
+    {
+        final List<AtlasGenerationTask> tasks = AtlasGenerator.generateTasks(countries, boundaryMap,
+                SHARDING);
+        Assert.assertEquals(expectedTaskSize, tasks.size());
+
+        // Verify that tasks have the same set of shards for the country
+        verifyAllShardEquality(tasks);
+
+        // Verify no shard is missed from tasks
+        verifyNoShardIsMissing(tasks);
+    }
+
+    private void verifyAllShardEquality(final List<AtlasGenerationTask> tasks)
+    {
+        final String referenceCountry = tasks.get(0).getCountry();
+        final List<Shard> referenceShards = tasks.get(0).getAllShards();
+        tasks.stream().skip(1).forEach(otherTask ->
+        {
+            Assert.assertEquals(referenceCountry, otherTask.getCountry());
+            Assert.assertEquals(referenceShards, otherTask.getAllShards());
+        });
+    }
+
+    private void verifyNoShardIsMissing(final List<AtlasGenerationTask> tasks)
+    {
+        final List<Shard> referenceShards = tasks.get(0).getAllShards();
+        final List<Shard> taskShards = tasks.stream().map(task -> task.getShard())
+                .collect(Collectors.toList());
+        Assert.assertEquals(referenceShards, taskShards);
     }
 }


### PR DESCRIPTION
This PR updates `AtlasGenerator` to generate `Shard` tasks in Spark master rather than doing it through Spark executors. This process doesn't need to be distributed over executors, because all the information needed for this operation is already available in the master and also the object used for this operation `CountryBoundaryMap` instance might not be not small. Passing `CountryBoundaryMap` instance back and forth adds extra cost and slows down the generation process.

- To make things faster, initial parallelization `JavaRDD` and `JavaPairRDD`s are removed and replaced with `generateTasks` method call. This method goes and generates `AtlasGenerationTask`s to be used in the generation process.
- `AtlasGenerationTaskProcessor` is created to generate tasks in parallel.
- Methods `roughShards` and `filterShards` are removed. Rather, `Sharding`'s `shards` method is being used. See https://github.com/osmlab/atlas/blob/0800d37ccff186d70723e6727934c91e1ff1ecc5/src/main/java/org/openstreetmap/atlas/geography/sharding/Sharding.java#L88 for implementation details.
- `PbfLoader`'s constructor is updated to accept `List` of `Shard`s for simplicity and reuse from `AtlasGenerator` side.
- `AtlasGeneratorTest` is updated with new tests.