### PR TITLE
Add additional write method to SparkFileHelper that accepts a byte array

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
@@ -503,6 +503,32 @@ public class SparkFileHelper implements Serializable
      * @param filename
      *            the name of the file
      * @param content
+     *            file content in byte array form
+     */
+    public void write(final String directory, final String filename, final byte[] content)
+    {
+        IO_RETRY.run(() ->
+        {
+            try
+            {
+                FileSystemHelper.writableResource(combine(directory, filename), this.sparkContext)
+                        .writeAndClose(content);
+            }
+            catch (final Exception e)
+            {
+                throw new CoreException(String.format("Could not save into %s.", filename), e);
+            }
+        });
+    }
+
+    /**
+     * Writes given content into given directory with given filename
+     *
+     * @param directory
+     *            a directory path to write files into
+     * @param filename
+     *            the name of the file
+     * @param content
      *            file content
      */
     public void write(final String directory, final String filename, final String content)

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
@@ -11,6 +11,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 
@@ -186,5 +187,27 @@ public class SparkFileHelperTest
         TEST_HELPER.rename(tempFile.getAbsolutePath(), tempFile2.getAbsolutePath());
         Assert.assertFalse(tempFile.exists());
         Assert.assertTrue(tempFile2.exists());
+    }
+
+    @Test
+    public void testWrite() throws IOException
+    {
+        final String testBytesFileName = "write_test_bytes";
+        final String testStringFileName = "write_test_string";
+        final byte[] testBytes = { 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, };
+        final String testString = "OsmRocks!";
+        final File testFolder = this.temporaryFolder.newFolder();
+        TEST_HELPER.write(testFolder.getAbsolutePath(), testBytesFileName, testBytes);
+
+        final String testByteResource = SparkFileHelper.combine(testFolder.getAbsolutePath(),
+                testBytesFileName);
+        Assert.assertArrayEquals("SparkFileHelper write with byteArray failed", testBytes,
+                FileSystemHelper.resource(testByteResource).readBytesAndClose());
+
+        TEST_HELPER.write(testFolder.getAbsolutePath(), testStringFileName, testString);
+        final String testStringResource = SparkFileHelper.combine(testFolder.getAbsolutePath(),
+                testStringFileName);
+        Assert.assertEquals("SparkFileHelper write with string failed", testString,
+                FileSystemHelper.resource(testStringResource).all());
     }
 }


### PR DESCRIPTION
SparkFileHelper currently supports a write method that accepts a String.  Most libraries also support accepting a byte array for general use cases - so proposing the same here.  Also added unit tests for both write methods!