### PR TITLE
commitByCopy

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
@@ -328,6 +328,33 @@ public class SparkFileHelper implements Serializable
     }
 
     /**
+     * Copies a file.
+     * <p>
+     * Copying of directories is not supported
+     * </p>
+     *
+     * @param sourcePath
+     *            - original file path.
+     * @param destinationPath
+     *            - destination path.
+     */
+    public void copyFile(final String sourcePath, final String destinationPath)
+    {
+        if (this.isDirectory(sourcePath))
+        {
+            final String message = String.format("Copy from {} to {} is failed.", sourcePath,
+                    destinationPath);
+            throw new CoreException(message,
+                    new UnsupportedOperationException("Copying directories is not supported."));
+        }
+
+        final Resource resource = FileSystemHelper.resource(sourcePath, this.sparkContext);
+        final WritableResource output = FileSystemHelper.writableResource(destinationPath,
+                this.sparkContext);
+        resource.copyTo(output);
+    }
+
+    /**
      * Deletes given directory and all it's child items
      *
      * @param path

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
@@ -65,6 +65,38 @@ public class SparkFileHelperTest
     }
 
     @Test
+    public void testCommitDirectoryByCopy() throws IOException
+    {
+        // Create temporary files
+        // Delete one and copy one to another
+        final File tempFolder = this.temporaryFolder.newFolder();
+        final File targetFolder = this.temporaryFolder.newFolder();
+
+        targetFolder.delete();
+
+        final File tempFile = File.createTempFile("test", FileSuffix.TEMPORARY.toString(),
+                tempFolder);
+        final File tempFile2 = File.createTempFile("test-another", FileSuffix.TEMPORARY.toString(),
+                tempFolder);
+
+        TEST_HELPER.commitByCopy(
+                new SparkFilePath(tempFolder.getAbsolutePath(), targetFolder.getAbsolutePath()));
+
+        Assert.assertTrue(tempFile.exists());
+        Assert.assertTrue(tempFile2.exists());
+
+        final String[] targetFile = targetFolder
+                .list((dir, name) -> name.equals(tempFile.getName()));
+        Assert.assertNotNull(targetFile);
+        Assert.assertEquals(1, targetFile.length);
+
+        final String[] targetFile2 = targetFolder
+                .list((dir, name) -> name.equals(tempFile.getName()));
+        Assert.assertNotNull(targetFile2);
+        Assert.assertEquals(1, targetFile2.length);
+    }
+
+    @Test
     public void testCommitFile() throws IOException
     {
         // Create temporary files
@@ -85,10 +117,10 @@ public class SparkFileHelperTest
     }
 
     @Test
-    public void testCopyFile() throws IOException
+    public void testCommitFileByFile() throws IOException
     {
         // Create temporary files
-        // Delete one and rename one to another
+        // Delete one and copy one to another
         final File tempFile = File.createTempFile("test", FileSuffix.TEMPORARY.toString());
         tempFile.deleteOnExit();
         Assert.assertTrue(tempFile.exists());
@@ -98,7 +130,8 @@ public class SparkFileHelperTest
         Assert.assertFalse(tempFile2.exists());
 
         // Rename test to test-another
-        TEST_HELPER.copyFile(tempFile.getAbsolutePath(), tempFile2.getAbsolutePath());
+        TEST_HELPER.commitByCopy(
+                new SparkFilePath(tempFile.getAbsolutePath(), tempFile2.getAbsolutePath()));
         Assert.assertTrue(tempFile.exists());
         Assert.assertTrue(tempFile2.exists());
     }

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
@@ -84,6 +84,25 @@ public class SparkFileHelperTest
         Assert.assertTrue(tempFile2.exists());
     }
 
+    @Test
+    public void testCopyFile() throws IOException
+    {
+        // Create temporary files
+        // Delete one and rename one to another
+        final File tempFile = File.createTempFile("test", FileSuffix.TEMPORARY.toString());
+        tempFile.deleteOnExit();
+        Assert.assertTrue(tempFile.exists());
+
+        final File tempFile2 = File.createTempFile("test-another", FileSuffix.TEMPORARY.toString());
+        tempFile2.delete();
+        Assert.assertFalse(tempFile2.exists());
+
+        // Rename test to test-another
+        TEST_HELPER.copyFile(tempFile.getAbsolutePath(), tempFile2.getAbsolutePath());
+        Assert.assertTrue(tempFile.exists());
+        Assert.assertTrue(tempFile2.exists());
+    }
+
     @Test(expected = CoreException.class)
     public void testDeleteNonExistingDirectory()
     {


### PR DESCRIPTION
Committing files by copying to target location.
In some environments renaming files may not be supported.
In case files need to be present in a final location but cannot be renamed there, they can be copied with sources deleted after that.
