### PR TITLE
Do not print configuration values in logs unless allowed

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
@@ -362,7 +362,8 @@ public abstract class SparkJob extends Command implements Serializable
     protected SwitchList switches()
     {
         return new SwitchList().with(INPUT, OUTPUT, STARTED_FOLDER, MASTER, SPARK_OPTIONS,
-                ADDITIONAL_SPARK_OPTIONS, COMPRESS_OUTPUT, SPARK_CONTEXT_PROVIDER);
+                ADDITIONAL_SPARK_OPTIONS, COMPRESS_OUTPUT, SPARK_CONTEXT_PROVIDER,
+                SENSITIVE_CONFIGURATION_PATTERN);
     }
 
     private void checkFileDoesNotExists(final String path, final String name)


### PR DESCRIPTION
This PR adds an option to not print some configuration values in the logs when their keys follow a specified pattern.