### PR TITLE
Include dependencies in shaded jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,8 @@ dependencies
 {
     compile packages.atlas
     compile packages.spark.core
+    
+    shaded project.configurations.getByName('compile')
 }
 
 task integrationTest(type: Test) {


### PR DESCRIPTION
This is to include all the compile dependencies into the shaded jar. Up to now, the shaded jar was empty.