### PR TITLE
Removing IsoCountry from Raw Atlas Generation

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.0.13',
+    atlas: '5.0.14',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]


### PR DESCRIPTION
DNM: This depends on an Atlas release with the changes fromthis Atlas [PR](https://github.com/osmlab/atlas/pull/112).

**Changes**:
1. Replacing country code representation from `IsoCountry` to `String`.
2. Updating logging to give more information as to which shard is being processed rather than which atlas file is being processed. This gives a lot more context as to what's going on when looking through the logs.

**Testing**:
1. Tested on a single country, multiple countries, large and small. Same results as in previous runs.