### PR TITLE
Make Spark pass the configuration around from the driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories
     // For Spark CDH
     maven { url "https://repository.cloudera.com/content/repositories/releases/" }
     // For jetty (through spark)
-    maven { url "http://repo.spring.io/plugins-release/" }
+    maven { url "http://repository.cloudera.com/cloudera/cloudera-repos/" }
 }
 
 idea {

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -182,16 +182,28 @@ public class AtlasGenerator extends SparkJob
         final Map<String, String> propertyMap = new HashMap<>();
         propertyMap.put(CODE_VERSION.getName(), (String) command.get(CODE_VERSION));
         propertyMap.put(DATA_VERSION.getName(), (String) command.get(DATA_VERSION));
-        propertyMap.put(EDGE_CONFIGURATION.getName(), FileSystemHelper
-                .resource((String) command.get(EDGE_CONFIGURATION), sparkContext).all());
-        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), FileSystemHelper
-                .resource((String) command.get(WAY_SECTIONING_CONFIGURATION), sparkContext).all());
-        propertyMap.put(PBF_NODE_CONFIGURATION.getName(), FileSystemHelper
-                .resource((String) command.get(PBF_NODE_CONFIGURATION), sparkContext).all());
-        propertyMap.put(PBF_WAY_CONFIGURATION.getName(), FileSystemHelper
-                .resource((String) command.get(PBF_WAY_CONFIGURATION), sparkContext).all());
-        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), FileSystemHelper
-                .resource((String) command.get(PBF_RELATION_CONFIGURATION), sparkContext).all());
+
+        final String edgeConfiguration = (String) command.get(EDGE_CONFIGURATION);
+        propertyMap.put(EDGE_CONFIGURATION.getName(), edgeConfiguration == null ? null
+                : FileSystemHelper.resource(edgeConfiguration, sparkContext).all());
+
+        final String waySectioningConfiguration = (String) command
+                .get(WAY_SECTIONING_CONFIGURATION);
+        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null
+                ? null : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
+
+        final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
+        propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
+                : FileSystemHelper.resource(pbfNodeConfiguration, sparkContext).all());
+
+        final String pbfWayConfiguration = (String) command.get(PBF_WAY_CONFIGURATION);
+        propertyMap.put(PBF_WAY_CONFIGURATION.getName(), pbfWayConfiguration == null ? null
+                : FileSystemHelper.resource(pbfWayConfiguration, sparkContext).all());
+
+        final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
+        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null
+                ? null : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
+
         propertyMap.put(CODE_VERSION.getName(), (String) command.get(CODE_VERSION));
         propertyMap.put(DATA_VERSION.getName(), (String) command.get(DATA_VERSION));
 

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -38,6 +38,7 @@ import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.tags.filters.ConfiguredTaggableFilter;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
@@ -163,6 +164,56 @@ public final class AtlasGeneratorHelper implements Serializable
                 return loadAtlas(fileFromNetwork);
             }
         };
+    }
+
+    protected static AtlasLoadingOption buildAtlasLoadingOption(final CountryBoundaryMap boundaries,
+            final Map<String, String> sparkContext, final Map<String, String> properties)
+    {
+        final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption
+                .createOptionWithAllEnabled(boundaries);
+
+        // Apply all configurations
+        final String edgeConfiguration = properties
+                .get(AtlasGenerator.EDGE_CONFIGURATION.getName());
+        if (edgeConfiguration != null)
+        {
+            atlasLoadingOption
+                    .setEdgeFilter(getTaggableFilterFrom(new StringResource(edgeConfiguration)));
+        }
+
+        final String waySectioningConfiguration = properties
+                .get(AtlasGenerator.WAY_SECTIONING_CONFIGURATION.getName());
+        if (waySectioningConfiguration != null)
+        {
+            atlasLoadingOption.setWaySectionFilter(
+                    getTaggableFilterFrom(new StringResource(waySectioningConfiguration)));
+        }
+
+        final String pbfNodeConfiguration = properties
+                .get(AtlasGenerator.PBF_NODE_CONFIGURATION.getName());
+        if (pbfNodeConfiguration != null)
+        {
+            atlasLoadingOption.setOsmPbfNodeFilter(
+                    getTaggableFilterFrom(new StringResource(pbfNodeConfiguration)));
+        }
+
+        final String pbfWayConfiguration = properties
+                .get(AtlasGenerator.PBF_WAY_CONFIGURATION.getName());
+        if (pbfWayConfiguration != null)
+        {
+            atlasLoadingOption.setOsmPbfWayFilter(
+                    getTaggableFilterFrom(new StringResource(pbfWayConfiguration)));
+        }
+
+        final String pbfRelationConfiguration = properties
+                .get(AtlasGenerator.PBF_RELATION_CONFIGURATION.getName());
+        if (pbfRelationConfiguration != null)
+        {
+            atlasLoadingOption.setOsmPbfRelationFilter(
+                    getTaggableFilterFrom(new StringResource(pbfRelationConfiguration)));
+        }
+
+        return atlasLoadingOption;
     }
 
     /**
@@ -303,16 +354,16 @@ public final class AtlasGeneratorHelper implements Serializable
         };
     }
 
-    protected static StandardConfiguration getStandardConfigurationFrom(final String path,
-            final Map<String, String> configuration)
+    protected static StandardConfiguration getStandardConfigurationFrom(
+            final Resource configurationResource)
     {
-        return new StandardConfiguration(FileSystemHelper.resource(path, configuration));
+        return new StandardConfiguration(configurationResource);
     }
 
-    protected static ConfiguredTaggableFilter getTaggableFilterFrom(final String path,
-            final Map<String, String> configuration)
+    protected static ConfiguredTaggableFilter getTaggableFilterFrom(
+            final Resource configurationResource)
     {
-        return new ConfiguredTaggableFilter(getStandardConfigurationFrom(path, configuration));
+        return new ConfiguredTaggableFilter(getStandardConfigurationFrom(configurationResource));
     }
 
     /**
@@ -434,56 +485,6 @@ public final class AtlasGeneratorHelper implements Serializable
             final Tuple2<String, Atlas> result = new Tuple2<>(tuple._1(), slicedAtlas);
             return result;
         };
-    }
-
-    private static AtlasLoadingOption buildAtlasLoadingOption(final CountryBoundaryMap boundaries,
-            final Map<String, String> sparkContext, final Map<String, String> properties)
-    {
-        final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption
-                .createOptionWithAllEnabled(boundaries);
-
-        // Apply all configurations
-        final String edgeConfiguration = properties
-                .get(AtlasGenerator.EDGE_CONFIGURATION.getName());
-        if (edgeConfiguration != null)
-        {
-            atlasLoadingOption
-                    .setEdgeFilter(getTaggableFilterFrom(edgeConfiguration, sparkContext));
-        }
-
-        final String waySectioningConfiguration = properties
-                .get(AtlasGenerator.WAY_SECTIONING_CONFIGURATION.getName());
-        if (waySectioningConfiguration != null)
-        {
-            atlasLoadingOption.setWaySectionFilter(
-                    getTaggableFilterFrom(waySectioningConfiguration, sparkContext));
-        }
-
-        final String pbfNodeConfiguration = properties
-                .get(AtlasGenerator.PBF_NODE_CONFIGURATION.getName());
-        if (pbfNodeConfiguration != null)
-        {
-            atlasLoadingOption
-                    .setOsmPbfNodeFilter(getTaggableFilterFrom(pbfNodeConfiguration, sparkContext));
-        }
-
-        final String pbfWayConfiguration = properties
-                .get(AtlasGenerator.PBF_WAY_CONFIGURATION.getName());
-        if (pbfWayConfiguration != null)
-        {
-            atlasLoadingOption
-                    .setOsmPbfWayFilter(getTaggableFilterFrom(pbfWayConfiguration, sparkContext));
-        }
-
-        final String pbfRelationConfiguration = properties
-                .get(AtlasGenerator.PBF_RELATION_CONFIGURATION.getName());
-        if (pbfRelationConfiguration != null)
-        {
-            atlasLoadingOption.setOsmPbfRelationFilter(
-                    getTaggableFilterFrom(pbfRelationConfiguration, sparkContext));
-        }
-
-        return atlasLoadingOption;
     }
 
     private static boolean fileExists(final String path, final Map<String, String> configuration)


### PR DESCRIPTION
This enhancement allows the driver to pass around the loading configurations, and thus each slave does not have to download the configuration from the same location.

Also the `propertyMap` contains full configuration files as `String`s.