### PR TITLE
Cleanup - removing duplicated fields, adding test failure stacktrace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ test
     testLogging
     {
         events "passed", "skipped", "failed"
+        exceptionFormat = 'full'
     }
 }
 

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -204,9 +204,6 @@ public class AtlasGenerator extends SparkJob
         propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null
                 ? null : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
 
-        propertyMap.put(CODE_VERSION.getName(), (String) command.get(CODE_VERSION));
-        propertyMap.put(DATA_VERSION.getName(), (String) command.get(DATA_VERSION));
-
         return propertyMap;
     }
 


### PR DESCRIPTION
Two changes here:

- Removing duplicated code and data version fields. See line 183-184 to find where they are kept.
- @lucaspcram and I found it useful to have the full stack trace present in any potential test failure in the `atlas` project. Adding the same here.