### PR TITLE
DNM: Synchronize by country instead of raw atlas stage

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -435,13 +435,15 @@ public final class AtlasGeneratorHelper implements Serializable
     }
 
     /**
+     * @param country
+     *            The country being processed
      * @param boundaries
      *            The {@link CountryBoundaryMap} to use for slicing
      * @return a Spark {@link PairFunction} that processes a tuple of shard-name and raw atlas,
      *         slices the raw atlas and returns the sliced raw atlas for that shard name.
      */
     protected static PairFunction<Tuple2<String, Atlas>, String, Atlas> sliceRawAtlas(
-            final CountryBoundaryMap boundaries)
+            final String country, final CountryBoundaryMap boundaries)
     {
         return tuple ->
         {
@@ -455,21 +457,8 @@ public final class AtlasGeneratorHelper implements Serializable
 
             try
             {
-                // Extract the country code
-                final String countryName = shardName.split(CountryShard.COUNTRY_SHARD_SEPARATOR)[0];
-                if (countryName != null)
-                {
-                    // Slice the Atlas
-                    slicedAtlas = new RawAtlasCountrySlicer(countryName, boundaries)
-                            .slice(rawAtlas);
-                }
-                else
-                {
-                    slicedAtlas = null;
-                    logger.error("Unable to extract valid country code for {}", shardName);
-                }
+                slicedAtlas = new RawAtlasCountrySlicer(country, boundaries).slice(rawAtlas);
             }
-
             catch (final Throwable e)
             {
                 throw new CoreException("Slicing raw Atlas failed for {}", shardName, e);

--- a/src/test/java/org/openstreetmap/atlas/generator/AtlasGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/AtlasGeneratorTest.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.maps.MultiMap;
 
 /**
  * Tests for {@link AtlasGenerator}.
@@ -75,15 +76,16 @@ public class AtlasGeneratorTest
     private void testCountry(final StringList countries, final CountryBoundaryMap boundaryMap,
             final int expectedTaskSize)
     {
-        final List<AtlasGenerationTask> tasks = AtlasGenerator.generateTasks(countries, boundaryMap,
-                SHARDING);
-        Assert.assertEquals(expectedTaskSize, tasks.size());
+        final MultiMap<String, AtlasGenerationTask> tasks = AtlasGenerator.generateTasks(countries,
+                boundaryMap, SHARDING);
+        final List<AtlasGenerationTask> allTasks = tasks.allValues();
+        Assert.assertEquals(expectedTaskSize, allTasks.size());
 
         // Verify that tasks have the same set of shards for the country
-        verifyAllShardEquality(tasks);
+        verifyAllShardEquality(allTasks);
 
         // Verify no shard is missed from tasks
-        verifyNoShardIsMissing(tasks);
+        verifyNoShardIsMissing(allTasks);
     }
 
     private void verifyAllShardEquality(final List<AtlasGenerationTask> tasks)


### PR DESCRIPTION
Previous implementation would synchronize across stages - once all raw atlases were built, then all slicing could start. Once all slicing would be completed, all sectioning could start. However, this didn't make sense - why does a small country that has relatively few shards have to wait for a large country with orders of magnitude more shards than it to complete? This PR updates the the synchronization of Spark stages (raw atlas creation, slicing, sectioning, statistics) to happen at the country level. As a result this allows more efficient executor utilization. Each executor can start be processing something instead of waiting for the last few shards of some stage to complete. 

DNM: This has encountered an issue when tested extensively at scale.