### PR TITLE
Optional filtering of source file 

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
@@ -242,7 +242,7 @@ public class SparkFileHelper implements Serializable
     {
         final Path path = new Path(uri);
         Resource resource = null;
-        if (Stream.of(filters).anyMatch(filter -> filter.accept(path)))
+        if (filters.length == 0 || Stream.of(filters).anyMatch(filter -> filter.accept(path)))
         {
             final String schema = URI.create(uri).getScheme();
             if ("http".equals(schema) || "https".equals(schema))

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
@@ -228,9 +228,9 @@ public class SparkFileHelper implements Serializable
     /**
      * Returns an Atlas {@link Resource} for the given location URI string. The resource is resolve
      * and returned if the URI points to single resource, not a resource directory, that conforms to
-     * a path defined by at least one of the provided {@link PathFilter}s. The {@link PathFilter}s
-     * provide a way to find well known data types that can be used either directly as or
-     * transformed to an Atlas.
+     * a path defined by one of the provided {@link PathFilter}s. The {@link PathFilter}s provide a
+     * way to find well known data types that can be used either directly as or transformed to an
+     * Atlas. With no filters, the file is collected.
      *
      * @param uri
      *            the location of the Atlas datasource


### PR DESCRIPTION
With no filters provided the file should be collected, currently at least one is required. The removes the need for a dummy path -> true predicate. 