### PR TITLE
Travis build: Break out sonar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
 script:
   - chmod -R ug+x .travis
   - .travis/build.sh
+  - .travis/sonar-gate.sh
   - .travis/merge-dev-to-master-gate.sh
   - .travis/deploy-gate.sh
   - .travis/tag-master-gate.sh

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -19,14 +19,3 @@ then
 else
 	./gradlew clean build
 fi
-
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ];
-then
-	echo "Running sonarqube in a CRON build"
-	./gradlew sonarqube \
-		-Dsonar.organization=osmlab \
-		-Dsonar.host.url=https://sonarcloud.io \
-		-Dsonar.login=$SONAR_TOKEN \
-		-Dsonar.junit.reportPaths=build/test-results/test \
-		-Dsonar.jacoco.reportPaths=build/jacoco/test.exec
-fi

--- a/.travis/sonar-gate.sh
+++ b/.travis/sonar-gate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+if [ $TRAVIS_TEST_RESULT -eq 0 ];
+then
+	.travis/sonar.sh
+	RETURN_VALUE=$?
+	if [ "$RETURN_VALUE" != "0" ];
+	then
+		exit $RETURN_VALUE
+	fi
+fi

--- a/.travis/sonar.sh
+++ b/.travis/sonar.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ];
+then
+	echo "Running sonarqube in a CRON build"
+	./gradlew sonarqube \
+		-Dsonar.organization=osmlab \
+		-Dsonar.host.url=https://sonarcloud.io \
+		-Dsonar.login=$SONAR_TOKEN \
+		-Dsonar.junit.reportPaths=build/test-results/test \
+		-Dsonar.jacoco.reportPaths=build/jacoco/test.exec
+fi

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
 	id 'jacoco'
 	id "com.diffplug.gradle.spotless" version "3.4.0"
 	id 'org.sonarqube' version '2.6'
-	id 'com.google.protobuf' version '0.8.1'
 	id "io.codearte.nexus-staging" version "0.8.0"
 }
 
@@ -61,7 +60,7 @@ dependencies
 {
     compile packages.atlas
     compile packages.spark.core
-    
+
     shaded project.configurations.getByName('compile')
 }
 


### PR DESCRIPTION
The sonar command within the build.sh script would have masked build errors within cron jobs. Breaking it out to follow the same pattern as in atlas.