### PR TITLE
Use latest Atlas library

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.1.3',
+    atlas: '5.1.5',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]


### PR DESCRIPTION
This uses the latest Atlas library for atlas-generator. For reference the changes included in the bump are from [5.1.4](https://github.com/osmlab/atlas/milestone/21?closed=1) and [5.1.5](https://github.com/osmlab/atlas/milestone/22?closed=1).