### PR TITLE
Use latest Atlas library

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.1.3',
+    atlas: '5.1.5',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.exception.CoreException;
-import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.geography.sharding.CountryShard;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.writers.SafeBufferedWriter;
@@ -38,7 +38,7 @@ public class AtlasShardVerifier extends Command
         @SuppressWarnings("unchecked")
         final Set<CountryShard> expectedShards = (Set<CountryShard>) command.get(EXPECTED_SHARDS);
         final Set<CountryShard> existingShards = atlasFolder.listFilesRecursively().stream()
-                .filter(Atlas::isAtlas).map(File::getName)
+                .filter(AtlasResourceLoader.IS_ATLAS).map(File::getName)
                 .map(name -> StringList.split(name, ".").get(0)).map(CountryShard::forName)
                 .collect(Collectors.toSet());
         expectedShards.removeAll(existingShards);


### PR DESCRIPTION
This uses the latest Atlas library for atlas-generator. For reference the changes included in the bump are from [5.1.4](https://github.com/osmlab/atlas/milestone/21?closed=1) and [5.1.5](https://github.com/osmlab/atlas/milestone/22?closed=1).