### PR TITLE
Added a HadoopAtlasFileCache

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.1.5',
+    atlas: '5.1.8',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -65,6 +65,8 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
             throw new CoreException("Bad URI syntax: {}", atlasURIString, exception);
         }
 
+        // this is bad because GLOBAL_STRATEGY is not synchronized properly here
+        // synchronization occurs at instance level on ConcurrentResourceCache
         return this.get(atlasURI);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -1,26 +1,70 @@
 package org.openstreetmap.atlas.generator.tools.caching;
 
 import java.net.URI;
-import java.util.function.Function;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
 
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.utilities.caching.ConcurrentResourceCache;
-import org.openstreetmap.atlas.utilities.caching.strategies.CachingStrategy;
+import org.openstreetmap.atlas.utilities.caching.strategies.SystemTemporaryFileCachingStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Cache an atlas file stored in the standard way (parentpath/COUNTRY/COUNTRY_z-x-y.atlas) to a
  * system temporary location. This cache is designed to be used with atlases that can be fetched
- * from a hadoop file system.
+ * from a hadoop file system. This cache is threadsafe.
  *
  * @author lcram
  */
 public class HadoopAtlasFileCache extends ConcurrentResourceCache
 {
+    /**
+     * This field can be static since there is only 1 global filesystem! The advantage to this
+     * approach is that all instances of {@link HadoopAtlasFileCache} will share the same underlying
+     * file cache, and so cross-cache hits are possible (and desired!).
+     */
+    private static final SystemTemporaryFileCachingStrategy GLOBAL_STRATEGY = new SystemTemporaryFileCachingStrategy();
+    private static final Logger logger = LoggerFactory.getLogger(HadoopAtlasFileCache.class);
 
-    public HadoopAtlasFileCache(final CachingStrategy cachingStrategy,
-            final Function<URI, Resource> fetcher)
+    private final String parentAtlasPath;
+
+    /**
+     * Create a new cache.
+     *
+     * @param parentAtlasPath
+     *            The parent path to the atlas files. This might look like hdfs://some/path/to/files
+     * @param configuration
+     *            The configuration map
+     */
+    public HadoopAtlasFileCache(final String parentAtlasPath,
+            final Map<String, String> configuration)
     {
-        super(cachingStrategy, fetcher);
-        // TODO Auto-generated constructor stub
+        super(GLOBAL_STRATEGY, uri -> FileSystemHelper.resource(uri.toString(), configuration));
+        this.parentAtlasPath = parentAtlasPath;
+    }
+
+    public Optional<Resource> get(final String country, final Shard shard)
+    {
+        final String atlasName = String.format("%s_%s", country, shard.getName());
+        final String atlasURIString = this.parentAtlasPath + "/" + country + "/" + atlasName
+                + FileSuffix.ATLAS.toString();
+        final URI atlasURI;
+
+        try
+        {
+            atlasURI = new URI(atlasURIString);
+        }
+        catch (final URISyntaxException exception)
+        {
+            throw new CoreException("Bad URI syntax: {}", atlasURIString, exception);
+        }
+
+        return this.get(atlasURI);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -7,8 +7,6 @@ import java.util.Optional;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
-import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.Resource;
@@ -55,7 +53,7 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
      *            The {@link Shard} object representing the shard
      * @return an {@link Optional} wrapping the shard
      */
-    public Optional<Atlas> get(final String country, final Shard shard)
+    public Optional<Resource> get(final String country, final Shard shard)
     {
         final String atlasName = String.format("%s_%s", country, shard.getName());
         final String atlasURIString = this.parentAtlasPath + "/" + country + "/" + atlasName
@@ -71,13 +69,6 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
             throw new CoreException("Bad URI syntax: {}", atlasURIString, exception);
         }
 
-        final Optional<Resource> atlasResourceOptional = this.get(atlasURI);
-
-        if (!atlasResourceOptional.isPresent())
-        {
-            return Optional.empty();
-        }
-
-        return Optional.ofNullable(new AtlasResourceLoader().load(atlasResourceOptional.get()));
+        return this.get(atlasURI);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -1,0 +1,26 @@
+package org.openstreetmap.atlas.generator.tools.caching;
+
+import java.net.URI;
+import java.util.function.Function;
+
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.utilities.caching.ConcurrentResourceCache;
+import org.openstreetmap.atlas.utilities.caching.strategies.CachingStrategy;
+
+/**
+ * Cache an atlas file stored in the standard way (parentpath/COUNTRY/COUNTRY_z-x-y.atlas) to a
+ * system temporary location. This cache is designed to be used with atlases that can be fetched
+ * from a hadoop file system.
+ *
+ * @author lcram
+ */
+public class HadoopAtlasFileCache extends ConcurrentResourceCache
+{
+
+    public HadoopAtlasFileCache(final CachingStrategy cachingStrategy,
+            final Function<URI, Resource> fetcher)
+    {
+        super(cachingStrategy, fetcher);
+        // TODO Auto-generated constructor stub
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.Resource;
@@ -46,14 +48,14 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
 
     /**
      * Get an {@link Optional} of an atlas resource specified by the given parameters.
-     * 
+     *
      * @param country
      *            The ISO country code of the desired shard
      * @param shard
      *            The {@link Shard} object representing the shard
      * @return an {@link Optional} wrapping the shard
      */
-    public Optional<Resource> get(final String country, final Shard shard)
+    public Optional<Atlas> get(final String country, final Shard shard)
     {
         final String atlasName = String.format("%s_%s", country, shard.getName());
         final String atlasURIString = this.parentAtlasPath + "/" + country + "/" + atlasName
@@ -69,6 +71,13 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
             throw new CoreException("Bad URI syntax: {}", atlasURIString, exception);
         }
 
-        return this.get(atlasURI);
+        final Optional<Resource> atlasResourceOptional = this.get(atlasURI);
+
+        if (!atlasResourceOptional.isPresent())
+        {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(new AtlasResourceLoader().load(atlasResourceOptional.get()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -50,7 +50,7 @@ public class HadoopAtlasFileCacheTest
         }
         finally
         {
-            parentAtlas.deleteRecursively();
+            parent.deleteRecursively();
         }
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -10,6 +10,9 @@ import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @author lcram
+ */
 public class HadoopAtlasFileCacheTest
 {
     private static final Logger logger = LoggerFactory.getLogger(HadoopAtlasFileCacheTest.class);
@@ -31,12 +34,14 @@ public class HadoopAtlasFileCacheTest
             final String path = "file://" + parentAtlas.toString();
             final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(path, new HashMap<>());
 
+            // cache miss, this will create the cached copy
             final Resource resource1 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();
             final Resource resource2 = cache.get("AAA", new SlippyTile(2, 2, 2)).get();
 
             Assert.assertEquals("1", resource1.firstLine());
             Assert.assertEquals("2", resource2.firstLine());
 
+            // cache hit, using cached copy
             final Resource resource3 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();
             final Resource resource4 = cache.get("AAA", new SlippyTile(2, 2, 2)).get();
 

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -1,0 +1,51 @@
+package org.openstreetmap.atlas.generator.tools.caching;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HadoopAtlasFileCacheTest
+{
+    private static final Logger logger = LoggerFactory.getLogger(HadoopAtlasFileCacheTest.class);
+
+    @Test
+    public void testCache()
+    {
+        final File parent = File.temporaryFolder();
+        final File parentAtlas = new File(parent + "/atlas");
+        final File parentAtlasCountry = new File(parentAtlas + "/AAA");
+        parentAtlasCountry.mkdirs();
+        try
+        {
+            final File atlas1 = parentAtlasCountry.child("AAA_1-1-1.atlas");
+            atlas1.writeAndClose("1");
+            final File atlas2 = parentAtlasCountry.child("AAA_2-2-2.atlas");
+            atlas2.writeAndClose("2");
+
+            final String path = "file://" + parentAtlas.toString();
+            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(path, new HashMap<>());
+
+            final Resource resource1 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();
+            final Resource resource2 = cache.get("AAA", new SlippyTile(2, 2, 2)).get();
+
+            Assert.assertEquals("1", resource1.firstLine());
+            Assert.assertEquals("2", resource2.firstLine());
+
+            final Resource resource3 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();
+            final Resource resource4 = cache.get("AAA", new SlippyTile(2, 2, 2)).get();
+
+            Assert.assertEquals("1", resource3.firstLine());
+            Assert.assertEquals("2", resource4.firstLine());
+        }
+        finally
+        {
+            parentAtlas.deleteRecursively();
+        }
+    }
+}


### PR DESCRIPTION
Added a subclass of `ConcurrentResourceCache` that provides an easy way of caching Hadoop atlas files in the local tmp file system. Additionally, I have bumped the `atlas` dependency up to `5.1.8`.

Testing Approach
------------------

I have included a unit test that demonstrates properly functionality of the cache. Use of this cache will replace multiple instances of duplicate, handcrafted local caching code.