### PR TITLE
Added command line switch that allows saving to proto format

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -17,6 +17,7 @@ import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.persistence.AbstractMultipleAtlasBasedOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasCountryStatisticsOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasOutputFormat;
+import org.openstreetmap.atlas.generator.persistence.MultipleAtlasProtoOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasStatisticsOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.delta.RemovedMultipleAtlasDeltaOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
@@ -143,6 +144,10 @@ public class AtlasGenerator extends SparkJob
                     + " always be attempted regardless of the number of countries it intersects according to the"
                     + " country boundary map's grid index.",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
+    // TODO - once we have the OK to go proto, change the default value of this switch to "true"
+    public static final Switch<Boolean> USE_PROTO_FORMAT = new Switch<>("useProtoFormat",
+            "Generate the atlas files using the protocol buffer atlas format.",
+            Boolean::parseBoolean, Optionality.OPTIONAL, "false");
 
     public static void main(final String[] args)
     {
@@ -265,10 +270,10 @@ public class AtlasGenerator extends SparkJob
         final String shouldAlwaysSliceConfiguration = (String) command
                 .get(SHOULD_ALWAYS_SLICE_CONFIGURATION);
         final Predicate<Taggable> shouldAlwaysSlicePredicate = shouldAlwaysSliceConfiguration == null
-                ? taggable -> false
-                : AtlasGeneratorHelper.getTaggableFilterFrom(
+                ? taggable -> false : AtlasGeneratorHelper.getTaggableFilterFrom(
                         FileSystemHelper.resource(shouldAlwaysSliceConfiguration, sparkContext));
         final String output = output(command);
+        final boolean useProtoFormat = (boolean) command.get(USE_PROTO_FORMAT);
 
         // This has to be converted here, as we need the Spark Context
         final Resource countryBoundaries = resource(countryShapes);
@@ -336,9 +341,18 @@ public class AtlasGenerator extends SparkJob
 
             // Persist the RDD and save the final atlas
             countryAtlasShardsRDD.cache();
-            countryAtlasShardsRDD.saveAsHadoopFile(
-                    getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
-                    MultipleAtlasOutputFormat.class, new JobConf(configuration()));
+            if (useProtoFormat)
+            {
+                countryAtlasShardsRDD.saveAsHadoopFile(
+                        getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
+                        MultipleAtlasProtoOutputFormat.class, new JobConf(configuration()));
+            }
+            else
+            {
+                countryAtlasShardsRDD.saveAsHadoopFile(
+                        getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
+                        MultipleAtlasOutputFormat.class, new JobConf(configuration()));
+            }
             logger.info("\n\n********** SAVED THE FINAL ATLAS **********\n");
 
             // Remove the sliced atlas RDD from cache since we've cached the final RDD
@@ -537,11 +551,21 @@ public class AtlasGenerator extends SparkJob
             // splitAndSaveAsHadoopFile(countryNonNullAtlasShardsRDD,
             // getAlternateParallelFolderOutput(output, ATLAS_FOLDER), Atlas.class,
             // MultipleAtlasOutputFormat.class, new CountrySplitter());
-            countryNonNullAtlasShardsRDD.saveAsHadoopFile(
-                    getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
-                    MultipleAtlasOutputFormat.class, new JobConf(configuration()));
+            if (useProtoFormat)
+            {
+                countryNonNullAtlasShardsRDD.saveAsHadoopFile(
+                        getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
+                        MultipleAtlasProtoOutputFormat.class, new JobConf(configuration()));
+            }
+            else
+            {
+                countryNonNullAtlasShardsRDD.saveAsHadoopFile(
+                        getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
+                        MultipleAtlasOutputFormat.class, new JobConf(configuration()));
+            }
             logger.info("\n\n********** SAVED THE ATLAS **********\n");
         }
+
     }
 
     @Override
@@ -566,6 +590,6 @@ public class AtlasGenerator extends SparkJob
                 PBF_SHARDING, PREVIOUS_OUTPUT_FOR_DELTA, CODE_VERSION, DATA_VERSION,
                 EDGE_CONFIGURATION, WAY_SECTIONING_CONFIGURATION, PBF_NODE_CONFIGURATION,
                 PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, ATLAS_SCHEME, USE_RAW_ATLAS,
-                SHOULD_ALWAYS_SLICE_CONFIGURATION);
+                SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_PROTO_FORMAT);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/AtlasProtoOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/AtlasProtoOutputFormat.java
@@ -1,0 +1,31 @@
+package org.openstreetmap.atlas.generator.persistence;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas.AtlasSerializationFormat;
+import org.openstreetmap.atlas.streaming.resource.AbstractWritableResource;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+
+public class AtlasProtoOutputFormat extends AbstractFileOutputFormat<Atlas>
+{
+
+    @Override
+    protected String fileExtension()
+    {
+        return FileSuffix.ATLAS.toString();
+    }
+
+    @Override
+    protected boolean isCompressed()
+    {
+        return false;
+    }
+
+    @Override
+    protected void save(final Atlas value, final AbstractWritableResource out)
+    {
+        final PackedAtlas packedValue = (PackedAtlas) value;
+        packedValue.setSaveSerializationFormat(AtlasSerializationFormat.PROTOBUF);
+        packedValue.save(out);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasProtoOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasProtoOutputFormat.java
@@ -1,0 +1,26 @@
+package org.openstreetmap.atlas.generator.persistence;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.util.Progressable;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+
+public class MultipleAtlasProtoOutputFormat extends AbstractMultipleAtlasBasedOutputFormat<Atlas>
+{
+    private AtlasProtoOutputFormat format = null;
+
+    @Override
+    protected RecordWriter<String, Atlas> getBaseRecordWriter(final FileSystem fileSystem,
+            final JobConf job, final String name, final Progressable progress) throws IOException
+    {
+        if (this.format == null)
+        {
+            this.format = new AtlasProtoOutputFormat();
+        }
+        return this.format.getRecordWriter(fileSystem, job, name, progress);
+    }
+
+}


### PR DESCRIPTION
An optional command line switch `useProtoFormat=true` can be provided to generate atlas files using the protocol buffer format. When this switch is not provided, it will be set to false by default.