### PR TITLE
Add stage names to be visible in AtlasGenerator job UI

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.1.8',
+    atlas: '5.1.9',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.1.9',
+    atlas: '5.1.8',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -308,6 +308,7 @@ public class AtlasGenerator extends SparkJob
 
             // Persist the RDD and save the intermediary state
             countryRawAtlasShardsRDD.cache();
+            this.getContext().setJobGroup("0", "Raw Atlas Extraction From PBF");
             countryRawAtlasShardsRDD.saveAsHadoopFile(
                     getAlternateSubFolderOutput(output, RAW_ATLAS_FOLDER), Text.class, Atlas.class,
                     MultipleAtlasOutputFormat.class, new JobConf(configuration()));
@@ -322,6 +323,7 @@ public class AtlasGenerator extends SparkJob
             final String slicedRawAtlasPath = getAlternateSubFolderOutput(output,
                     SLICED_RAW_ATLAS_FOLDER);
             countrySlicedRawAtlasShardsRDD.cache();
+            this.getContext().setJobGroup("1", "Raw Atlas Country Slicing");
             countrySlicedRawAtlasShardsRDD.saveAsHadoopFile(slicedRawAtlasPath, Text.class,
                     Atlas.class, MultipleAtlasOutputFormat.class, new JobConf(configuration()));
             logger.info("\n\n********** SAVED THE SLICED RAW ATLAS **********\n");
@@ -336,6 +338,7 @@ public class AtlasGenerator extends SparkJob
 
             // Persist the RDD and save the final atlas
             countryAtlasShardsRDD.cache();
+            this.getContext().setJobGroup("2", "Raw Atlas Way Sectioning");
             countryAtlasShardsRDD.saveAsHadoopFile(
                     getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
                     MultipleAtlasOutputFormat.class, new JobConf(configuration()));
@@ -350,6 +353,7 @@ public class AtlasGenerator extends SparkJob
 
             // Persist the RDD and save
             statisticsRDD.cache();
+            this.getContext().setJobGroup("3", "Shard Statistics Creation");
             statisticsRDD.saveAsHadoopFile(
                     getAlternateSubFolderOutput(output, SHARD_STATISTICS_FOLDER), Text.class,
                     AtlasStatistics.class, MultipleAtlasStatisticsOutputFormat.class,
@@ -366,6 +370,7 @@ public class AtlasGenerator extends SparkJob
                     }).reduceByKey(AtlasStatistics::merge);
 
             // Save aggregated metrics
+            this.getContext().setJobGroup("4", "Country Statistics Creation");
             reducedStatisticsRDD.saveAsHadoopFile(
                     getAlternateSubFolderOutput(output, COUNTRY_STATISTICS_FOLDER), Text.class,
                     AtlasStatistics.class, MultipleAtlasCountryStatisticsOutputFormat.class,
@@ -380,6 +385,7 @@ public class AtlasGenerator extends SparkJob
                                 previousOutputForDelta));
 
                 // Save the deltas
+                this.getContext().setJobGroup("5", "Deltas Creation");
                 deltasRDD.saveAsHadoopFile(getAlternateSubFolderOutput(output, SHARD_DELTAS_FOLDER),
                         Text.class, AtlasDelta.class, RemovedMultipleAtlasDeltaOutputFormat.class,
                         new JobConf(configuration()));

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -202,8 +202,7 @@ public class AtlasGenerator extends SparkJob
         final String waySectioningConfiguration = (String) command
                 .get(WAY_SECTIONING_CONFIGURATION);
         propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null
-                ? null
-                : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
+                ? null : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
 
         final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
         propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
@@ -214,9 +213,8 @@ public class AtlasGenerator extends SparkJob
                 : FileSystemHelper.resource(pbfWayConfiguration, sparkContext).all());
 
         final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
-        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
-                pbfRelationConfiguration == null ? null
-                        : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
+        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null
+                ? null : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
 
         return propertyMap;
     }
@@ -263,8 +261,7 @@ public class AtlasGenerator extends SparkJob
         final String shardingName = (String) command.get(SHARDING_TYPE);
         final Sharding sharding = AtlasSharding.forString(shardingName, configuration());
         final Sharding pbfSharding = pbfShardingName != null
-                ? AtlasSharding.forString(pbfShardingName, configuration())
-                : sharding;
+                ? AtlasSharding.forString(pbfShardingName, configuration()) : sharding;
         final PbfContext pbfContext = new PbfContext(pbfPath, pbfSharding, pbfScheme);
         final String codeVersion = (String) command.get(CODE_VERSION);
         final String dataVersion = (String) command.get(DATA_VERSION);


### PR DESCRIPTION
### Description:

Spark allows users to define some stage description so those show up in the UI.

### Potential Impact:

None.

### Unit Test Approach:

This is visual only. No unit test.

### Test Results:

Tested on a local spark cluster:
<img width="436" alt="image" src="https://user-images.githubusercontent.com/1944860/44871071-a6260d80-ac46-11e8-86b8-0f7a7492c365.png">


------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
