### PR TITLE
Switched caching to use HadoopAtlasFileCache instead of custom code

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -329,8 +329,6 @@ public final class AtlasGeneratorHelper implements Serializable
                 // Create the fetcher
                 final Function<Shard, Optional<Atlas>> slicedRawAtlasFetcher = AtlasGeneratorHelper
                         .atlasFetcher(atlasCache, country, possibleShards);
-
-                logger.info("Started sectioning raw Atlas for {}", countryShardString);
                 // Section the Atlas
                 atlas = new WaySectionProcessor(countryShard.getShard(), atlasLoadingOption,
                         sharding, slicedRawAtlasFetcher).run();


### PR DESCRIPTION
### Description:

This PR replaces the custom caching code for atlas files with HadoopAtlasFileCache. 

### Potential Impact:

In theory, nothing-- the existing code used the same approach to caching that the HadoopAtlasFileCache implementation does. Given that the implementations are slightly different, it is always possible that some performance changes could occur, but none were apparent during sanity tests.

### Unit Test Approach:

There does not seem to be a very good way to unit test this functionality; I am open to suggestions.

### Test Results:

All existing test pass.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
