### PR TITLE
Added a default boundary map and configuration options to WorldAtlasGenerator

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/world/WorldAtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/world/WorldAtlasGeneratorIntegrationTest.java
@@ -1,0 +1,50 @@
+package org.openstreetmap.atlas.generator.world;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.AtlasGeneratorIntegrationTest;
+import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+
+public class WorldAtlasGeneratorIntegrationTest
+{
+    static
+    {
+        addResource("resource://test/pbf/9/9-168-233.osm.pbf", "DMA_cutout.osm.pbf");
+    }
+
+    private static void addResource(final String path, final String name)
+    {
+        ResourceFileSystem.addResource(path, new InputStreamResource(
+                () -> AtlasGeneratorIntegrationTest.class.getResourceAsStream(name)));
+    }
+
+    @Test
+    public void testWorldAtlasGenerator()
+    {
+        final String[] args = { "-pbf=resource://test/pbf/9/9-168-233.osm.pbf",
+                "-atlas=resource://test/output/atlas/9-168-233.atlas" };
+        final WorldAtlasGenerator worldAtlasGenerator = new WorldAtlasGenerator();
+        final Map<String, String> configuration = new HashMap<>();
+        configuration.put("fs.resource.impl", ResourceFileSystem.class.getCanonicalName());
+        worldAtlasGenerator.setHadoopFileSystemConfiguration(configuration);
+        ResourceFileSystem.printContents();
+        worldAtlasGenerator.runWithoutQuitting(args);
+        ResourceFileSystem.printContents();
+        try (ResourceFileSystem resourceFileSystem = new ResourceFileSystem())
+        {
+            Assert.assertTrue(resourceFileSystem
+                    .exists(new Path("resource://test/output/atlas/9-168-233.atlas")));
+        }
+        catch (IllegalArgumentException | IOException e)
+        {
+            throw new CoreException("Unable to find output Atlas files.", e);
+        }
+    }
+}

--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/world/WorldAtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/world/WorldAtlasGeneratorIntegrationTest.java
@@ -12,6 +12,9 @@ import org.openstreetmap.atlas.generator.AtlasGeneratorIntegrationTest;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 
+/**
+ * @author jwpgage
+ */
 public class WorldAtlasGeneratorIntegrationTest
 {
     static

--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.generator.AtlasGeneratorHelper;
 import org.openstreetmap.atlas.geography.MultiPolygon;
+import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasMetaData;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
@@ -19,8 +20,11 @@ import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.tags.Taggable;
+import org.openstreetmap.atlas.tags.filters.ConfiguredTaggableFilter;
 import org.openstreetmap.atlas.utilities.collections.Maps;
+import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
 import org.openstreetmap.atlas.utilities.conversion.StringConverter;
 import org.openstreetmap.atlas.utilities.runtime.Command;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
@@ -45,7 +49,7 @@ public class WorldAtlasGenerator extends Command
             "The file that will contain the statistics", File::new, Optionality.OPTIONAL);
     public static final Switch<CountryBoundaryMap> BOUNDARIES = new Switch<>("boundaries",
             "The boundary map to use", value -> CountryBoundaryMap.fromPlainText(new File(value)),
-            Optionality.REQUIRED);
+            Optionality.OPTIONAL);
     public static final Switch<String> CODE_VERSION = new Switch<>("codeVersion",
             "The code version", StringConverter.IDENTITY, Optionality.OPTIONAL, "unknown");
     public static final Switch<String> DATA_VERSION = new Switch<>("dataVersion",
@@ -59,6 +63,20 @@ public class WorldAtlasGenerator extends Command
                     + " always be attempted regardless of the number of countries it intersects according to the"
                     + " country boundary map's grid index.",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<File> PBF_WAY_CONFIGURATION = new Switch<>("osmPbfWayConfiguration",
+            "The path to the configuration file that defines which PBF Ways becomes an Atlas Entity.",
+            File::new, Optionality.OPTIONAL);
+    public static final Switch<File> PBF_NODE_CONFIGURATION = new Switch<>(
+            "osmPbfNodeConfiguration",
+            "The path to the configuration file that defines which PBF Nodes becomes an Atlas Entity.",
+            File::new, Optionality.OPTIONAL);
+    public static final Switch<File> PBF_RELATION_CONFIGURATION = new Switch<>(
+            "osmPbfRelationConfiguration",
+            "The path to the configuration file that defines which PBF Relations becomes an Atlas Entity",
+            File::new, Optionality.OPTIONAL);
+    // filter that does no filtering
+    private static final ConfiguredTaggableFilter PBF_NO_FILTER_CONFIGURATION = new ConfiguredTaggableFilter(
+            new StandardConfiguration(new StringResource("{\n    \"filters\": [\n\n    ]\n}")));
 
     public static void main(final String[] args)
     {
@@ -68,7 +86,16 @@ public class WorldAtlasGenerator extends Command
     @Override
     protected int onRun(final CommandMap command)
     {
-        final CountryBoundaryMap countryBoundaryMap = (CountryBoundaryMap) command.get(BOUNDARIES);
+        CountryBoundaryMap countryBoundaryMap = (CountryBoundaryMap) command.get(BOUNDARIES);
+        if (countryBoundaryMap == null)
+        {
+            final StringResource wholeWorld = new StringResource(
+                    "AAA||" + Rectangle.MAXIMUM.toWkt());
+            countryBoundaryMap = CountryBoundaryMap.fromPlainText(wholeWorld);
+        }
+        final File pbfWayConfiguration = (File) command.get(PBF_WAY_CONFIGURATION);
+        final File pbfNodeConfiguration = (File) command.get(PBF_NODE_CONFIGURATION);
+        final File pbfRelationConfiguration = (File) command.get(PBF_RELATION_CONFIGURATION);
         final File pbf = (File) command.get(PBF);
         final File output = (File) command.get(ATLAS);
         final File statisticsOutput = (File) command.get(STATISTICS);
@@ -88,6 +115,33 @@ public class WorldAtlasGenerator extends Command
         final AtlasLoadingOption loadingOptions = AtlasLoadingOption
                 .createOptionWithAllEnabled(countryBoundaryMap)
                 .setAdditionalCountryCodes(countryBoundaryMap.allCountryNames());
+        if (pbfWayConfiguration == null)
+        {
+            loadingOptions.setOsmPbfWayFilter(PBF_NO_FILTER_CONFIGURATION);
+        }
+        else
+        {
+            loadingOptions.setOsmPbfWayFilter(
+                    new ConfiguredTaggableFilter(new StandardConfiguration(pbfWayConfiguration)));
+        }
+        if (pbfNodeConfiguration == null)
+        {
+            loadingOptions.setOsmPbfNodeFilter(PBF_NO_FILTER_CONFIGURATION);
+        }
+        else
+        {
+            loadingOptions.setOsmPbfNodeFilter(
+                    new ConfiguredTaggableFilter(new StandardConfiguration(pbfNodeConfiguration)));
+        }
+        if (pbfRelationConfiguration == null)
+        {
+            loadingOptions.setOsmPbfRelationFilter(PBF_NO_FILTER_CONFIGURATION);
+        }
+        else
+        {
+            loadingOptions.setOsmPbfRelationFilter(new ConfiguredTaggableFilter(
+                    new StandardConfiguration(pbfRelationConfiguration)));
+        }
         final AtlasMetaData metaData = new AtlasMetaData(null, true, codeVersion, dataVersion,
                 "WORLD", world.getName(), Maps.hashMap());
 
@@ -126,10 +180,13 @@ public class WorldAtlasGenerator extends Command
 
         logger.info("Saving world atlas to {}", output);
         atlas.save(output);
-        logger.info("Generating world statistics...");
-        final AtlasStatistics statistics = counter.processAtlas(atlas);
-        logger.info("Saving world statistics to {}", statisticsOutput);
-        statistics.save(statisticsOutput);
+        if (statisticsOutput != null)
+        {
+            logger.info("Generating world statistics...");
+            final AtlasStatistics statistics = counter.processAtlas(atlas);
+            logger.info("Saving world statistics to {}", statisticsOutput);
+            statistics.save(statisticsOutput);
+        }
 
         logger.info("Finished creating world atlas in {}", start.elapsedSince());
 
@@ -140,7 +197,8 @@ public class WorldAtlasGenerator extends Command
     protected SwitchList switches()
     {
         return new SwitchList().with(PBF, ATLAS, STATISTICS, BOUNDARIES, CODE_VERSION, DATA_VERSION,
-                SHOULD_ALWAYS_SLICE_CONFIGURATION);
+                SHOULD_ALWAYS_SLICE_CONFIGURATION, PBF_WAY_CONFIGURATION, PBF_NODE_CONFIGURATION,
+                PBF_RELATION_CONFIGURATION);
     }
 
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
@@ -77,7 +77,7 @@ public class WorldAtlasGenerator extends Command
             File::new, Optionality.OPTIONAL);
     // filter that does no filtering
     private static final ConfiguredTaggableFilter PBF_NO_FILTER_CONFIGURATION = new ConfiguredTaggableFilter(
-            new StandardConfiguration(new StringResource("{\n    \"filters\": [\n\n    ]\n}")));
+            new StandardConfiguration(new StringResource("{\"filters\": []}")));
 
     public static void main(final String[] args)
     {

--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
@@ -47,6 +47,7 @@ public class WorldAtlasGenerator extends Command
             "The atlas file to which the Atlas will be saved", File::new, Optionality.REQUIRED);
     private static final Switch<File> STATISTICS = new Switch<>("statistics",
             "The file that will contain the statistics", File::new, Optionality.OPTIONAL);
+    // the default boundary is a bounding box of the world
     public static final Switch<CountryBoundaryMap> BOUNDARIES = new Switch<>("boundaries",
             "The boundary map to use", value -> CountryBoundaryMap.fromPlainText(new File(value)),
             Optionality.OPTIONAL);


### PR DESCRIPTION
### Description:

Added a default boundary map to `WorldAtlasGenerator`, and changed the required flag to optional for the country boundary map parameter. This allows `WorldAtlasGenerator` to be used to create boundary maps from pbf.

This PR also adds the ability to set custom node, relation, and way filters in `WorldAtlasGenerator`, which was also necessary for border file generation.

### Potential Impact:

The default country boundary map provided is set to the width of the world, and a fake country "AAA". Therefore a country boundary map parameter should still be passed in most use cases.

### Unit Test Approach:

N/A

### Test Results:

Tested default boundary map as a part of country boundary map generation.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)