### PR TITLE
Protect AtlasGenerator from failing statistics

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -202,23 +202,23 @@ public final class AtlasGeneratorHelper implements Serializable
     {
         return tuple ->
         {
-            logger.info("Starting generating Atlas statistics for {}", tuple._1());
+            final String shardName = tuple._1();
+            logger.info("Starting generating Atlas statistics for {}", shardName);
             final Time start = Time.now();
             final Counter counter = new Counter().withSharding(sharding);
             counter.setCountsDefinition(Counter.POI_COUNTS_DEFINITION.getDefault());
-            final AtlasStatistics statistics;
+            AtlasStatistics statistics = new AtlasStatistics();
             try
             {
                 statistics = counter.processAtlas(tuple._2());
+                logger.info("Finished generating Atlas statistics for {} in {}", shardName,
+                        start.elapsedSince());
             }
             catch (final Exception e)
             {
-                throw new CoreException("Building Atlas Statistics for {} failed!", tuple._1(), e);
+                logger.error("Building Atlas Statistics for {} failed!", shardName, e);
             }
-            logger.info("Finished generating Atlas statistics for {} in {}", tuple._1(),
-                    start.elapsedSince());
-            final Tuple2<String, AtlasStatistics> result = new Tuple2<>(tuple._1(), statistics);
-            return result;
+            return new Tuple2<>(shardName, statistics);
         };
     }
 


### PR DESCRIPTION
### Description:

Protect AtlasGenerator from failing statistics. This is related to an error fixed here: https://github.com/osmlab/atlas/pull/243

### Potential Impact:

Statistics failures will be logged and not fail the job.

### Unit Test Approach:

TBD

### Test Results:

TBD

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)