### PR TITLE
Travis - Use trusty and sudo false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ branches:
 language: java
 jdk:
   - oraclejdk8
+sudo: false
+dist: trusty
 before_install:
   - chmod -R ug+x .travis
   - .travis/install.sh


### PR DESCRIPTION
### Description:

This fixes https://github.com/osmlab/atlas/issues/242 for the atlas-generator project. (Similar to https://github.com/osmlab/atlas/pull/245)

### Potential Impact:

Use sudo=false and dist=trusty in builds. That solves the issue as per https://github.com/travis-ci/travis-ci/issues/9555#issuecomment-413187047

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)