### PR TITLE
DNM: AtlasGenerator cleanup and fix AtlasScheme being dropped

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -137,7 +137,9 @@
 			<property name="forceStrictCondition" value="false"/>
 		</module> -->
 		<module name="OuterTypeFilename"/>
-		<module name="TrailingComment"/>
+		<module name="TrailingComment">
+            <property name="legalComment" value="NOSONAR"/>
+        </module>
 		<module name="TodoComment" />
 		<module name="UpperEll" />
 	</module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -138,8 +138,8 @@
 		</module> -->
 		<module name="OuterTypeFilename"/>
 		<module name="TrailingComment">
-            <property name="legalComment" value="NOSONAR"/>
-        </module>
+			<property name="legalComment" value="NOSONAR"/>
+		</module>
 		<module name="TodoComment" />
 		<module name="UpperEll" />
 	</module>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.1.8',
+    atlas: '5.2.3',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -125,8 +125,7 @@ public class AtlasGenerator extends SparkJob
         final String shardingName = (String) command.get(AtlasGeneratorParameters.SHARDING_TYPE);
         final Sharding sharding = AtlasSharding.forString(shardingName, configuration());
         final Sharding pbfSharding = pbfShardingName != null
-                ? AtlasSharding.forString(pbfShardingName, configuration())
-                : sharding;
+                ? AtlasSharding.forString(pbfShardingName, configuration()) : sharding;
         final PbfContext pbfContext = new PbfContext(pbfPath, pbfSharding, pbfScheme);
         final String shouldAlwaysSliceConfiguration = (String) command
                 .get(AtlasGeneratorParameters.SHOULD_ALWAYS_SLICE_CONFIGURATION);

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -1,12 +1,9 @@
 package org.openstreetmap.atlas.generator;
 
-import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -14,8 +11,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.broadcast.Broadcast;
-import org.openstreetmap.atlas.exception.CoreException;
-import org.openstreetmap.atlas.generator.persistence.AbstractMultipleAtlasBasedOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasCountryStatisticsOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasProtoOutputFormat;
@@ -27,21 +22,17 @@ import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
-import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.statistics.AtlasStatistics;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMapArchiver;
 import org.openstreetmap.atlas.geography.boundary.CountryShardListing;
-import org.openstreetmap.atlas.geography.sharding.CountryShard;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.tags.Taggable;
 import org.openstreetmap.atlas.utilities.collections.StringList;
-import org.openstreetmap.atlas.utilities.conversion.StringConverter;
 import org.openstreetmap.atlas.utilities.maps.MultiMapWithSet;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
-import org.openstreetmap.atlas.utilities.runtime.system.memory.Memory;
 import org.openstreetmap.atlas.utilities.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,21 +47,6 @@ import scala.Tuple2;
  */
 public class AtlasGenerator extends SparkJob
 {
-    /**
-     * @author matthieun
-     */
-    @SuppressWarnings("unused")
-    private static class CountrySplitter implements Serializable, Function<String, String>
-    {
-        private static final long serialVersionUID = 6984474253285033371L;
-
-        @Override
-        public String apply(final String key)
-        {
-            return StringList.split(key, CountryShard.COUNTRY_SHARD_SEPARATOR).get(0);
-        }
-    }
-
     private static final long serialVersionUID = 5985696743749843135L;
 
     private static final Logger logger = LoggerFactory.getLogger(AtlasGenerator.class);
@@ -83,71 +59,6 @@ public class AtlasGenerator extends SparkJob
     public static final String SHARD_DELTAS_ADDED_FOLDER = "deltasAdded";
     public static final String SHARD_DELTAS_CHANGED_FOLDER = "deltasChanged";
     public static final String SHARD_DELTAS_REMOVED_FOLDER = "deltasRemoved";
-
-    private static final String SHARDING_DEFAULT = "slippy@10";
-
-    public static final Switch<StringList> COUNTRIES = new Switch<>("countries",
-            "Comma separated list of countries to be included in the final Atlas",
-            value -> StringList.split(value, ","), Optionality.REQUIRED);
-    public static final Switch<String> COUNTRY_SHAPES = new Switch<>("countryShapes",
-            "Shape file containing the countries", StringConverter.IDENTITY, Optionality.REQUIRED);
-    public static final Switch<String> PBF_PATH = new Switch<>("pbfs", "The path to PBFs",
-            StringConverter.IDENTITY, Optionality.REQUIRED);
-    public static final Switch<SlippyTilePersistenceScheme> PBF_SCHEME = new Switch<>("pbfScheme",
-            "The folder structure of the PBF", SlippyTilePersistenceScheme::new,
-            Optionality.OPTIONAL, PbfLocator.DEFAULT_SCHEME);
-    public static final Switch<String> PBF_SHARDING = new Switch<>("pbfSharding",
-            "The sharding tree of the pbf files. If not specified, this will default to the general Atlas sharding.",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
-    public static final Switch<SlippyTilePersistenceScheme> ATLAS_SCHEME = new Switch<>(
-            "atlasScheme",
-            "The folder structure of the output Atlas. Example: \"zz/xx/yy/\" or \"\""
-                    + " (everything under the same folder)",
-            SlippyTilePersistenceScheme::new, Optionality.OPTIONAL,
-            AbstractMultipleAtlasBasedOutputFormat.DEFAULT_SCHEME);
-    public static final Switch<String> SHARDING_TYPE = new Switch<>("sharding",
-            "The sharding definition.", StringConverter.IDENTITY, Optionality.OPTIONAL,
-            SHARDING_DEFAULT);
-    public static final Switch<String> PREVIOUS_OUTPUT_FOR_DELTA = new Switch<>(
-            "previousOutputForDelta",
-            "The path of the output of the previous job that can be used for delta computation",
-            StringConverter.IDENTITY, Optionality.OPTIONAL, "");
-    public static final Switch<String> CODE_VERSION = new Switch<>("codeVersion",
-            "The code version", StringConverter.IDENTITY, Optionality.OPTIONAL, "unknown");
-    public static final Switch<String> DATA_VERSION = new Switch<>("dataVersion",
-            "The data version", StringConverter.IDENTITY, Optionality.OPTIONAL, "unknown");
-    public static final Switch<String> EDGE_CONFIGURATION = new Switch<>("edgeConfiguration",
-            "The path to the configuration file that defines what OSM Way becomes an Edge",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
-    public static final Switch<String> WAY_SECTIONING_CONFIGURATION = new Switch<>(
-            "waySectioningConfiguration",
-            "The path to the configuration file that defines where to section Ways to make Edges.",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
-    public static final Switch<String> PBF_WAY_CONFIGURATION = new Switch<>(
-            "osmPbfWayConfiguration",
-            "The path to the configuration file that defines which PBF Ways becomes an Atlas Entity.",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
-    public static final Switch<String> PBF_NODE_CONFIGURATION = new Switch<>(
-            "osmPbfNodeConfiguration",
-            "The path to the configuration file that defines which PBF Nodes becomes an Atlas Entity.",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
-    public static final Switch<String> PBF_RELATION_CONFIGURATION = new Switch<>(
-            "osmPbfRelationConfiguration",
-            "The path to the configuration file that defines which PBF Relations becomes an Atlas Entity",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
-    // TODO - once this is fully baked and tested, remove flag and old flow
-    public static final Switch<Boolean> USE_RAW_ATLAS = new Switch<>("useRawAtlas",
-            "Allow PBF to Atlas process to use Raw Atlas flow", Boolean::parseBoolean,
-            Optionality.OPTIONAL, "false");
-    public static final Switch<String> SHOULD_ALWAYS_SLICE_CONFIGURATION = new Switch<>(
-            "shouldAlwaysSliceConfiguration",
-            "The path to the configuration file that defines which entities on which country slicing will"
-                    + " always be attempted regardless of the number of countries it intersects according to the"
-                    + " country boundary map's grid index.",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
-    public static final Switch<Boolean> USE_JAVA_FORMAT = new Switch<>("useJavaFormat",
-            "Generate the atlas files using the java serialization atlas format (as opposed to the protobuf format).",
-            Boolean::parseBoolean, Optionality.OPTIONAL, "false");
 
     public static void main(final String[] args)
     {
@@ -189,37 +100,6 @@ public class AtlasGenerator extends SparkJob
         return tasks;
     }
 
-    private static Map<String, String> extractAtlasLoadingProperties(final CommandMap command,
-            final Map<String, String> sparkContext)
-    {
-        final Map<String, String> propertyMap = new HashMap<>();
-        propertyMap.put(CODE_VERSION.getName(), (String) command.get(CODE_VERSION));
-        propertyMap.put(DATA_VERSION.getName(), (String) command.get(DATA_VERSION));
-
-        final String edgeConfiguration = (String) command.get(EDGE_CONFIGURATION);
-        propertyMap.put(EDGE_CONFIGURATION.getName(), edgeConfiguration == null ? null
-                : FileSystemHelper.resource(edgeConfiguration, sparkContext).all());
-
-        final String waySectioningConfiguration = (String) command
-                .get(WAY_SECTIONING_CONFIGURATION);
-        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null
-                ? null : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
-
-        final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
-        propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
-                : FileSystemHelper.resource(pbfNodeConfiguration, sparkContext).all());
-
-        final String pbfWayConfiguration = (String) command.get(PBF_WAY_CONFIGURATION);
-        propertyMap.put(PBF_WAY_CONFIGURATION.getName(), pbfWayConfiguration == null ? null
-                : FileSystemHelper.resource(pbfWayConfiguration, sparkContext).all());
-
-        final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
-        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null
-                ? null : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
-
-        return propertyMap;
-    }
-
     @Override
     public String getName()
     {
@@ -229,52 +109,39 @@ public class AtlasGenerator extends SparkJob
     @Override
     public void start(final CommandMap command)
     {
-        // logger.info("***********************Classpath:**********************");
-        // final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-        // final URL[] urls = ((URLClassLoader) classLoader).getURLs();
-        // for (final URL url : urls)
-        // {
-        // logger.info(url.getFile());
-        // final File file = new File(url.getFile());
-        // if (file.isDirectory())
-        // {
-        // file.listFilesRecursively()
-        // .forEach(sub -> logger.info("\t{}", sub.getAbsolutePath()));
-        // }
-        // }
-        // logger.info("*******************************************************");
-        // final Class clazz = DOMParser.class;
-        // logger.info("##########$$$$$$$$$--" + clazz.getSimpleName() + ": "
-        // + clazz.getProtectionDomain().getCodeSource() + ": "
-        // + clazz.getProtectionDomain().getCodeSource().getLocation());
-
         final Map<String, String> sparkContext = configurationMap();
 
-        final StringList countries = (StringList) command.get(COUNTRIES);
-        final String countryShapes = (String) command.get(COUNTRY_SHAPES);
-        final String previousOutputForDelta = (String) command.get(PREVIOUS_OUTPUT_FOR_DELTA);
-        final String pbfPath = (String) command.get(PBF_PATH);
+        final StringList countries = (StringList) command.get(AtlasGeneratorParameters.COUNTRIES);
+        final String countryShapes = (String) command.get(AtlasGeneratorParameters.COUNTRY_SHAPES);
+        final String previousOutputForDelta = (String) command
+                .get(AtlasGeneratorParameters.PREVIOUS_OUTPUT_FOR_DELTA);
+        final String pbfPath = (String) command.get(AtlasGeneratorParameters.PBF_PATH);
         final SlippyTilePersistenceScheme pbfScheme = (SlippyTilePersistenceScheme) command
-                .get(PBF_SCHEME);
+                .get(AtlasGeneratorParameters.PBF_SCHEME);
         final SlippyTilePersistenceScheme atlasScheme = (SlippyTilePersistenceScheme) command
-                .get(ATLAS_SCHEME);
-        final String pbfShardingName = (String) command.get(PBF_SHARDING);
-        final String shardingName = (String) command.get(SHARDING_TYPE);
+                .get(AtlasGeneratorParameters.ATLAS_SCHEME);
+        final String pbfShardingName = (String) command.get(AtlasGeneratorParameters.PBF_SHARDING);
+        final String shardingName = (String) command.get(AtlasGeneratorParameters.SHARDING_TYPE);
         final Sharding sharding = AtlasSharding.forString(shardingName, configuration());
         final Sharding pbfSharding = pbfShardingName != null
-                ? AtlasSharding.forString(pbfShardingName, configuration()) : sharding;
+                ? AtlasSharding.forString(pbfShardingName, configuration())
+                : sharding;
         final PbfContext pbfContext = new PbfContext(pbfPath, pbfSharding, pbfScheme);
-        final String codeVersion = (String) command.get(CODE_VERSION);
-        final String dataVersion = (String) command.get(DATA_VERSION);
-        final boolean useRawAtlas = (boolean) command.get(USE_RAW_ATLAS);
         final String shouldAlwaysSliceConfiguration = (String) command
-                .get(SHOULD_ALWAYS_SLICE_CONFIGURATION);
-        final Predicate<Taggable> shouldAlwaysSlicePredicate = shouldAlwaysSliceConfiguration == null
-                ? taggable -> false
-                : AtlasGeneratorHelper.getTaggableFilterFrom(
-                        FileSystemHelper.resource(shouldAlwaysSliceConfiguration, sparkContext));
+                .get(AtlasGeneratorParameters.SHOULD_ALWAYS_SLICE_CONFIGURATION);
+        final Predicate<Taggable> shouldAlwaysSlicePredicate;
+        if (shouldAlwaysSliceConfiguration == null)
+        {
+            shouldAlwaysSlicePredicate = taggable -> false;
+        }
+        else
+        {
+            shouldAlwaysSlicePredicate = AtlasGeneratorParameters.getTaggableFilterFrom(
+                    FileSystemHelper.resource(shouldAlwaysSliceConfiguration, sparkContext));
+        }
         final String output = output(command);
-        final boolean useJavaFormat = (boolean) command.get(USE_JAVA_FORMAT);
+        final boolean useJavaFormat = (boolean) command
+                .get(AtlasGeneratorParameters.USE_JAVA_FORMAT);
 
         // This has to be converted here, as we need the Spark Context
         final Resource countryBoundaries = resource(countryShapes);
@@ -300,8 +167,8 @@ public class AtlasGenerator extends SparkJob
         // AtlasLoadingOption isn't serializable, neither is command map. To avoid duplicating
         // boiler-plate code for creating the AtlasLoadingOption, extract the properties we need
         // from the command map and pass those around to create the AtlasLoadingOption
-        final Map<String, String> atlasLoadingOptions = extractAtlasLoadingProperties(command,
-                sparkContext);
+        final Map<String, String> atlasLoadingOptions = AtlasGeneratorParameters
+                .extractAtlasLoadingProperties(command, sparkContext);
 
         // Leverage Spark broadcast to have a read-only variable cached on each machine, instead of
         // shipping a copy with each task. All of these are re-used across tasks and are unchanged.
@@ -311,277 +178,106 @@ public class AtlasGenerator extends SparkJob
                 .broadcast(atlasLoadingOptions);
         final Broadcast<Sharding> broadcastSharding = getContext().broadcast(sharding);
 
-        if (useRawAtlas)
+        // Generate the raw Atlas and filter any null atlases
+        final JavaPairRDD<String, Atlas> countryRawAtlasShardsRDD = getContext()
+                .parallelize(tasks, tasks.size())
+                .mapToPair(AtlasGeneratorHelper.generateRawAtlas(broadcastBoundaries, sparkContext,
+                        broadcastLoadingOptions, pbfContext, atlasScheme))
+                .filter(tuple -> tuple._2() != null);
+
+        // Persist the RDD and save the intermediary state
+        countryRawAtlasShardsRDD.cache();
+        this.getContext().setJobGroup("0", "Raw Atlas Extraction From PBF");
+        countryRawAtlasShardsRDD.saveAsHadoopFile(
+                getAlternateSubFolderOutput(output, RAW_ATLAS_FOLDER), Text.class, Atlas.class,
+                MultipleAtlasOutputFormat.class, new JobConf(configuration()));
+        logger.info("\n\n********** SAVED THE RAW ATLAS **********\n");
+
+        // Slice the raw Atlas and filter any null atlases
+        final JavaPairRDD<String, Atlas> countrySlicedRawAtlasShardsRDD = countryRawAtlasShardsRDD
+                .mapToPair(AtlasGeneratorHelper.sliceRawAtlas(broadcastBoundaries))
+                .filter(tuple -> tuple._2() != null);
+
+        // Persist the RDD and save the intermediary state
+        final String slicedRawAtlasPath = getAlternateSubFolderOutput(output,
+                SLICED_RAW_ATLAS_FOLDER);
+        countrySlicedRawAtlasShardsRDD.cache();
+        this.getContext().setJobGroup("1", "Raw Atlas Country Slicing");
+        countrySlicedRawAtlasShardsRDD.saveAsHadoopFile(slicedRawAtlasPath, Text.class, Atlas.class,
+                MultipleAtlasOutputFormat.class, new JobConf(configuration()));
+        logger.info("\n\n********** SAVED THE SLICED RAW ATLAS **********\n");
+
+        // Remove the raw atlas RDD from cache since we've cached the sliced RDD
+        countryRawAtlasShardsRDD.unpersist();
+
+        // Section the sliced raw Atlas
+        final JavaPairRDD<String, Atlas> countryAtlasShardsRDD = countrySlicedRawAtlasShardsRDD
+                .mapToPair(AtlasGeneratorHelper.sectionRawAtlas(broadcastBoundaries,
+                        broadcastSharding, sparkContext, broadcastLoadingOptions,
+                        slicedRawAtlasPath, atlasScheme, tasks));
+
+        // Persist the RDD and save the final atlas
+        countryAtlasShardsRDD.cache();
+        this.getContext().setJobGroup("2", "Raw Atlas Way Sectioning");
+        if (useJavaFormat)
         {
-            // Generate the raw Atlas and filter any null atlases
-            final JavaPairRDD<String, Atlas> countryRawAtlasShardsRDD = getContext()
-                    .parallelize(tasks, tasks.size())
-                    .mapToPair(AtlasGeneratorHelper.generateRawAtlas(broadcastBoundaries,
-                            sparkContext, broadcastLoadingOptions, pbfContext, atlasScheme))
-                    .filter(tuple -> tuple._2() != null);
-
-            // Persist the RDD and save the intermediary state
-            countryRawAtlasShardsRDD.cache();
-            this.getContext().setJobGroup("0", "Raw Atlas Extraction From PBF");
-            countryRawAtlasShardsRDD.saveAsHadoopFile(
-                    getAlternateSubFolderOutput(output, RAW_ATLAS_FOLDER), Text.class, Atlas.class,
+            countryAtlasShardsRDD.saveAsHadoopFile(
+                    getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
                     MultipleAtlasOutputFormat.class, new JobConf(configuration()));
-            logger.info("\n\n********** SAVED THE RAW ATLAS **********\n");
-
-            // Slice the raw Atlas and filter any null atlases
-            final JavaPairRDD<String, Atlas> countrySlicedRawAtlasShardsRDD = countryRawAtlasShardsRDD
-                    .mapToPair(AtlasGeneratorHelper.sliceRawAtlas(broadcastBoundaries))
-                    .filter(tuple -> tuple._2() != null);
-
-            // Persist the RDD and save the intermediary state
-            final String slicedRawAtlasPath = getAlternateSubFolderOutput(output,
-                    SLICED_RAW_ATLAS_FOLDER);
-            countrySlicedRawAtlasShardsRDD.cache();
-            this.getContext().setJobGroup("1", "Raw Atlas Country Slicing");
-            countrySlicedRawAtlasShardsRDD.saveAsHadoopFile(slicedRawAtlasPath, Text.class,
-                    Atlas.class, MultipleAtlasOutputFormat.class, new JobConf(configuration()));
-            logger.info("\n\n********** SAVED THE SLICED RAW ATLAS **********\n");
-
-            // Remove the raw atlas RDD from cache since we've cached the sliced RDD
-            countryRawAtlasShardsRDD.unpersist();
-
-            // Section the sliced raw Atlas
-            final JavaPairRDD<String, Atlas> countryAtlasShardsRDD = countrySlicedRawAtlasShardsRDD
-                    .mapToPair(AtlasGeneratorHelper.sectionRawAtlas(broadcastBoundaries,
-                            broadcastSharding, sparkContext, broadcastLoadingOptions,
-                            slicedRawAtlasPath, tasks));
-
-            // Persist the RDD and save the final atlas
-            countryAtlasShardsRDD.cache();
-            this.getContext().setJobGroup("2", "Raw Atlas Way Sectioning");
-            if (useJavaFormat)
-            {
-                countryAtlasShardsRDD.saveAsHadoopFile(
-                        getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
-                        MultipleAtlasOutputFormat.class, new JobConf(configuration()));
-            }
-            else
-            {
-                countryAtlasShardsRDD.saveAsHadoopFile(
-                        getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
-                        MultipleAtlasProtoOutputFormat.class, new JobConf(configuration()));
-            }
-            logger.info("\n\n********** SAVED THE FINAL ATLAS **********\n");
-
-            // Remove the sliced atlas RDD from cache since we've cached the final RDD
-            countrySlicedRawAtlasShardsRDD.unpersist();
-
-            // Create the metrics
-            final JavaPairRDD<String, AtlasStatistics> statisticsRDD = countryAtlasShardsRDD
-                    .mapToPair(AtlasGeneratorHelper.generateAtlasStatistics(broadcastSharding));
-
-            // Persist the RDD and save
-            statisticsRDD.cache();
-            this.getContext().setJobGroup("3", "Shard Statistics Creation");
-            statisticsRDD.saveAsHadoopFile(
-                    getAlternateSubFolderOutput(output, SHARD_STATISTICS_FOLDER), Text.class,
-                    AtlasStatistics.class, MultipleAtlasStatisticsOutputFormat.class,
-                    new JobConf(configuration()));
-            logger.info("\n\n********** SAVED THE SHARD STATISTICS **********\n");
-
-            // Aggregate the metrics
-            final JavaPairRDD<String, AtlasStatistics> reducedStatisticsRDD = statisticsRDD
-                    .mapToPair(tuple ->
-                    {
-                        final String countryShardName = tuple._1();
-                        final String countryName = StringList.split(countryShardName, "_").get(0);
-                        return new Tuple2<>(countryName, tuple._2());
-                    }).reduceByKey(AtlasStatistics::merge);
-
-            // Save aggregated metrics
-            this.getContext().setJobGroup("4", "Country Statistics Creation");
-            reducedStatisticsRDD.saveAsHadoopFile(
-                    getAlternateSubFolderOutput(output, COUNTRY_STATISTICS_FOLDER), Text.class,
-                    AtlasStatistics.class, MultipleAtlasCountryStatisticsOutputFormat.class,
-                    new JobConf(configuration()));
-            logger.info("\n\n********** SAVED THE COUNTRY STATISTICS **********\n");
-
-            // Compute the deltas, if needed
-            if (!previousOutputForDelta.isEmpty())
-            {
-                final JavaPairRDD<String, AtlasDelta> deltasRDD = countryAtlasShardsRDD
-                        .flatMapToPair(AtlasGeneratorHelper.computeAtlasDelta(sparkContext,
-                                previousOutputForDelta));
-
-                // Save the deltas
-                this.getContext().setJobGroup("5", "Deltas Creation");
-                deltasRDD.saveAsHadoopFile(getAlternateSubFolderOutput(output, SHARD_DELTAS_FOLDER),
-                        Text.class, AtlasDelta.class, RemovedMultipleAtlasDeltaOutputFormat.class,
-                        new JobConf(configuration()));
-                logger.info("\n\n********** SAVED THE DELTAS **********\n");
-            }
         }
         else
         {
-            // Transform the map country name to shard to country name to Atlas
-            // This is not enforced, but it has to be a 1-1 mapping here.
-            final JavaPairRDD<String, Atlas> countryAtlasShardsRDD = getContext()
-                    .parallelize(tasks, tasks.size()).mapToPair(task ->
-                    {
-                        // Get the country name
-                        final String countryName = task.getCountry();
-                        // Get the country shard
-                        final Shard shard = task.getShard();
-                        // Build the AtlasLoadingOption
-                        final AtlasLoadingOption atlasLoadingOption = AtlasGeneratorHelper
-                                .buildAtlasLoadingOption(boundaries, sparkContext,
-                                        atlasLoadingOptions)
-                                .setAdditionalCountryCodes(countryName);
-
-                        // Build the appropriate PbfLoader
-                        final PbfLoader loader = new PbfLoader(pbfContext, sparkContext, boundaries,
-                                atlasLoadingOption, codeVersion, dataVersion, task.getAllShards());
-                        final String name = countryName + CountryShard.COUNTRY_SHARD_SEPARATOR
-                                + shard.getName();
-
-                        logger.info("Starting building Atlas {}", name);
-                        final Time start = Time.now();
-
-                        final Atlas atlas;
-                        try
-                        {
-                            // Generate the Atlas for this shard
-                            atlas = loader.load(countryName, shard);
-                        }
-                        catch (final Throwable e)
-                        {
-                            throw new CoreException("Building Atlas {} failed!", name, e);
-                        }
-
-                        logger.info("Finished building Atlas {} in {}", name, start.elapsedSince());
-
-                        // Report on memory usage
-                        logger.info("Printing memory after loading Atlas {}", name);
-                        Memory.printCurrentMemory();
-
-                        // Output the Name/Atlas couple
-                        final Tuple2<String, Atlas> result = new Tuple2<>(name
-                                + CountryShard.COUNTRY_SHARD_SEPARATOR + atlasScheme.getScheme(),
-                                atlas);
-                        return result;
-                    });
-
-            // Filter out null Atlas
-            final JavaPairRDD<String, Atlas> countryNonNullAtlasShardsRDD = countryAtlasShardsRDD
-                    .filter(tuple -> tuple._2() != null);
-
-            // Cache the Atlas
-            countryNonNullAtlasShardsRDD.cache();
-            logger.info("\n\n********** CACHED THE ATLAS **********\n");
-
-            // Run the metrics
-            final JavaPairRDD<String, AtlasStatistics> statisticsRDD = countryNonNullAtlasShardsRDD
-                    .mapToPair(AtlasGeneratorHelper.generateAtlasStatistics(broadcastSharding));
-
-            // Cache the statistics
-            statisticsRDD.cache();
-            logger.info("\n\n********** CACHED THE SHARD STATISTICS **********\n");
-
-            // Save the metrics
-            // splitAndSaveAsHadoopFile(statisticsRDD,
-            // getAlternateParallelFolderOutput(output, SHARD_STATISTICS_FOLDER),
-            // AtlasStatistics.class, MultipleAtlasStatisticsOutputFormat.class,
-            // new CountrySplitter());
-            statisticsRDD.saveAsHadoopFile(
-                    getAlternateSubFolderOutput(output, SHARD_STATISTICS_FOLDER), Text.class,
-                    AtlasStatistics.class, MultipleAtlasStatisticsOutputFormat.class,
-                    new JobConf(configuration()));
-            logger.info("\n\n********** SAVED THE SHARD STATISTICS **********\n");
-
-            // Aggregate the metrics
-            final JavaPairRDD<String, AtlasStatistics> reducedStatisticsRDD = statisticsRDD
-                    .mapToPair(tuple ->
-                    {
-                        final String countryShardName = tuple._1();
-                        final String countryName = StringList.split(countryShardName, "_").get(0);
-                        return new Tuple2<>(countryName, tuple._2());
-                    }).reduceByKey(AtlasStatistics::merge);
-
-            // Save the aggregated metrics
-            // reducedStatisticsRDD.saveAsHadoopFile(
-            // getAlternateSubFolderOutput(output, COUNTRY_STATISTICS_FOLDER), Text.class,
-            // AtlasStatistics.class, MultipleAtlasStatisticsOutputFormat.class,
-            // new JobConf(configuration()));
-            reducedStatisticsRDD.saveAsHadoopFile(
-                    getAlternateSubFolderOutput(output, COUNTRY_STATISTICS_FOLDER), Text.class,
-                    AtlasStatistics.class, MultipleAtlasCountryStatisticsOutputFormat.class,
-                    new JobConf(configuration()));
-            logger.info("\n\n********** SAVED THE COUNTRY STATISTICS **********\n");
-
-            // Compute the deltas if needed
-            if (!previousOutputForDelta.isEmpty())
-            {
-                // Compute the deltas
-                final JavaPairRDD<String, AtlasDelta> deltasRDD = countryNonNullAtlasShardsRDD
-                        .flatMapToPair(AtlasGeneratorHelper.computeAtlasDelta(sparkContext,
-                                previousOutputForDelta));
-
-                // deltasRDD.cache();
-                // logger.info("\n\n********** CACHED THE DELTAS **********\n");
-
-                // Save the deltas
-                // splitAndSaveAsHadoopFile(deltasRDD, getAlternateOutput(output,
-                // SHARD_DELTAS_FOLDER),
-                // AtlasDelta.class, MultipleAtlasDeltaOutputFormat.class,
-                // COUNTRY_NAME_FROM_COUNTRY_SHARD);
-                // deltasRDD.saveAsHadoopFile(getAlternateOutput(output, SHARD_DELTAS_FOLDER),
-                // Text.class,
-                // AtlasDelta.class, MultipleAtlasDeltaOutputFormat.class,
-                // new JobConf(configuration()));
-                // logger.info("\n\n********** SAVED THE DELTAS **********\n");
-                //
-                // splitAndSaveAsHadoopFile(deltasRDD,
-                // getAlternateOutput(output, SHARD_DELTAS_ADDED_FOLDER), AtlasDelta.class,
-                // AddedMultipleAtlasDeltaOutputFormat.class, COUNTRY_NAME_FROM_COUNTRY_SHARD);
-                // deltasRDD.saveAsHadoopFile(getAlternateOutput(output, SHARD_DELTAS_ADDED_FOLDER),
-                // Text.class, AtlasDelta.class, AddedMultipleAtlasDeltaOutputFormat.class,
-                // new JobConf(configuration()));
-                // logger.info("\n\n********** SAVED THE DELTAS ADDED **********\n");
-                //
-                // splitAndSaveAsHadoopFile(deltasRDD,
-                // getAlternateOutput(output, SHARD_DELTAS_CHANGED_FOLDER), AtlasDelta.class,
-                // ChangedMultipleAtlasDeltaOutputFormat.class, COUNTRY_NAME_FROM_COUNTRY_SHARD);
-                // deltasRDD.saveAsHadoopFile(getAlternateOutput(output,
-                // SHARD_DELTAS_CHANGED_FOLDER),
-                // Text.class, AtlasDelta.class, ChangedMultipleAtlasDeltaOutputFormat.class,
-                // new JobConf(configuration()));
-                // logger.info("\n\n********** SAVED THE DELTAS CHANGED **********\n");
-
-                // splitAndSaveAsHadoopFile(deltasRDD,
-                // getAlternateParallelFolderOutput(output, SHARD_DELTAS_REMOVED_FOLDER),
-                // AtlasDelta.class, RemovedMultipleAtlasDeltaOutputFormat.class,
-                // new CountrySplitter());
-                deltasRDD.saveAsHadoopFile(
-                        getAlternateSubFolderOutput(output, SHARD_DELTAS_REMOVED_FOLDER),
-                        Text.class, AtlasDelta.class, RemovedMultipleAtlasDeltaOutputFormat.class,
-                        new JobConf(configuration()));
-                logger.info("\n\n********** SAVED THE DELTAS REMOVED **********\n");
-            }
-
-            // Save the result as Atlas files, one for each key.
-            // splitAndSaveAsHadoopFile(countryNonNullAtlasShardsRDD,
-            // getAlternateParallelFolderOutput(output, ATLAS_FOLDER), Atlas.class,
-            // MultipleAtlasOutputFormat.class, new CountrySplitter());
-            if (useJavaFormat)
-            {
-                countryNonNullAtlasShardsRDD.saveAsHadoopFile(
-                        getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
-                        MultipleAtlasOutputFormat.class, new JobConf(configuration()));
-            }
-            else
-            {
-                countryNonNullAtlasShardsRDD.saveAsHadoopFile(
-                        getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
-                        MultipleAtlasProtoOutputFormat.class, new JobConf(configuration()));
-            }
-            logger.info("\n\n********** SAVED THE ATLAS **********\n");
+            countryAtlasShardsRDD.saveAsHadoopFile(
+                    getAlternateSubFolderOutput(output, ATLAS_FOLDER), Text.class, Atlas.class,
+                    MultipleAtlasProtoOutputFormat.class, new JobConf(configuration()));
         }
+        logger.info("\n\n********** SAVED THE FINAL ATLAS **********\n");
 
+        // Remove the sliced atlas RDD from cache since we've cached the final RDD
+        countrySlicedRawAtlasShardsRDD.unpersist();
+
+        // Create the metrics
+        final JavaPairRDD<String, AtlasStatistics> statisticsRDD = countryAtlasShardsRDD
+                .mapToPair(AtlasGeneratorHelper.generateAtlasStatistics(broadcastSharding));
+
+        // Persist the RDD and save
+        statisticsRDD.cache();
+        this.getContext().setJobGroup("3", "Shard Statistics Creation");
+        statisticsRDD.saveAsHadoopFile(getAlternateSubFolderOutput(output, SHARD_STATISTICS_FOLDER),
+                Text.class, AtlasStatistics.class, MultipleAtlasStatisticsOutputFormat.class,
+                new JobConf(configuration()));
+        logger.info("\n\n********** SAVED THE SHARD STATISTICS **********\n");
+
+        // Aggregate the metrics
+        final JavaPairRDD<String, AtlasStatistics> reducedStatisticsRDD = statisticsRDD
+                .mapToPair(tuple ->
+                {
+                    final String countryShardName = tuple._1();
+                    final String countryName = StringList.split(countryShardName, "_").get(0);
+                    return new Tuple2<>(countryName, tuple._2());
+                }).reduceByKey(AtlasStatistics::merge);
+
+        // Save aggregated metrics
+        this.getContext().setJobGroup("4", "Country Statistics Creation");
+        reducedStatisticsRDD.saveAsHadoopFile(
+                getAlternateSubFolderOutput(output, COUNTRY_STATISTICS_FOLDER), Text.class,
+                AtlasStatistics.class, MultipleAtlasCountryStatisticsOutputFormat.class,
+                new JobConf(configuration()));
+        logger.info("\n\n********** SAVED THE COUNTRY STATISTICS **********\n");
+
+        // Compute the deltas, if needed
+        if (!previousOutputForDelta.isEmpty())
+        {
+            final JavaPairRDD<String, AtlasDelta> deltasRDD = countryAtlasShardsRDD.flatMapToPair(
+                    AtlasGeneratorHelper.computeAtlasDelta(sparkContext, previousOutputForDelta));
+
+            // Save the deltas
+            this.getContext().setJobGroup("5", "Deltas Creation");
+            deltasRDD.saveAsHadoopFile(getAlternateSubFolderOutput(output, SHARD_DELTAS_FOLDER),
+                    Text.class, AtlasDelta.class, RemovedMultipleAtlasDeltaOutputFormat.class,
+                    new JobConf(configuration()));
+            logger.info("\n\n********** SAVED THE DELTAS **********\n");
+        }
     }
 
     @Override
@@ -602,10 +298,8 @@ public class AtlasGenerator extends SparkJob
     @Override
     protected SwitchList switches()
     {
-        return super.switches().with(COUNTRIES, COUNTRY_SHAPES, SHARDING_TYPE, PBF_PATH, PBF_SCHEME,
-                PBF_SHARDING, PREVIOUS_OUTPUT_FOR_DELTA, CODE_VERSION, DATA_VERSION,
-                EDGE_CONFIGURATION, WAY_SECTIONING_CONFIGURATION, PBF_NODE_CONFIGURATION,
-                PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, ATLAS_SCHEME, USE_RAW_ATLAS,
-                SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT);
+        final SwitchList result = super.switches();
+        result.addAll(AtlasGeneratorParameters.switches());
+        return result;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -195,6 +195,8 @@ public final class AtlasGeneratorHelper implements Serializable
      *            The basic required properties to create an {@link AtlasLoadingOption}
      * @param pbfContext
      *            The context explaining where to find the PBFs
+     * @param atlasScheme
+     *            The folder structure of the output atlas
      * @return a Spark {@link PairFunction} that processes an {@link AtlasGenerationTask}, loads the
      *         PBF for the task's shard, generates the raw atlas for the shard and outputs a shard
      *         name to raw atlas tuple.
@@ -341,9 +343,6 @@ public final class AtlasGeneratorHelper implements Serializable
     /**
      * @param boundaries
      *            The {@link CountryBoundaryMap} to use for slicing
-     * @param atlasScheme
-     *            The persistence scheme used to save Atlas files, so the input files can be
-     *            properly found
      * @return a Spark {@link PairFunction} that processes a tuple of shard-name and raw atlas,
      *         slices the raw atlas and returns the sliced raw atlas for that shard name.
      */

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -1,0 +1,192 @@
+package org.openstreetmap.atlas.generator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openstreetmap.atlas.generator.persistence.AbstractMultipleAtlasBasedOutputFormat;
+import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
+import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+import org.openstreetmap.atlas.tags.filters.ConfiguredTaggableFilter;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
+import org.openstreetmap.atlas.utilities.conversion.StringConverter;
+import org.openstreetmap.atlas.utilities.runtime.Command.Optionality;
+import org.openstreetmap.atlas.utilities.runtime.Command.Switch;
+import org.openstreetmap.atlas.utilities.runtime.Command.SwitchList;
+import org.openstreetmap.atlas.utilities.runtime.CommandMap;
+
+/**
+ * @author matthieun
+ */
+public final class AtlasGeneratorParameters
+{
+    private static final String SHARDING_DEFAULT = "slippy@10";
+
+    public static final Switch<StringList> COUNTRIES = new Switch<>("countries",
+            "Comma separated list of countries to be included in the final Atlas",
+            value -> StringList.split(value, ","), Optionality.REQUIRED);
+    public static final Switch<String> COUNTRY_SHAPES = new Switch<>("countryShapes",
+            "Shape file containing the countries", StringConverter.IDENTITY, Optionality.REQUIRED);
+    public static final Switch<String> PBF_PATH = new Switch<>("pbfs", "The path to PBFs",
+            StringConverter.IDENTITY, Optionality.REQUIRED);
+    public static final Switch<SlippyTilePersistenceScheme> PBF_SCHEME = new Switch<>("pbfScheme",
+            "The folder structure of the PBF", SlippyTilePersistenceScheme::new,
+            Optionality.OPTIONAL, PbfLocator.DEFAULT_SCHEME);
+    public static final Switch<String> PBF_SHARDING = new Switch<>("pbfSharding",
+            "The sharding tree of the pbf files. If not specified, this will default to the general Atlas sharding.",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<SlippyTilePersistenceScheme> ATLAS_SCHEME = new Switch<>(
+            "atlasScheme",
+            "The folder structure of the output Atlas. Example: \"zz/xx/yy/\" or \"\""
+                    + " (everything under the same folder)",
+            SlippyTilePersistenceScheme::new, Optionality.OPTIONAL,
+            AbstractMultipleAtlasBasedOutputFormat.DEFAULT_SCHEME);
+    public static final Switch<String> SHARDING_TYPE = new Switch<>("sharding",
+            "The sharding definition.", StringConverter.IDENTITY, Optionality.OPTIONAL,
+            SHARDING_DEFAULT);
+    public static final Switch<String> PREVIOUS_OUTPUT_FOR_DELTA = new Switch<>(
+            "previousOutputForDelta",
+            "The path of the output of the previous job that can be used for delta computation",
+            StringConverter.IDENTITY, Optionality.OPTIONAL, "");
+    public static final Switch<String> CODE_VERSION = new Switch<>("codeVersion",
+            "The code version", StringConverter.IDENTITY, Optionality.OPTIONAL, "unknown");
+    public static final Switch<String> DATA_VERSION = new Switch<>("dataVersion",
+            "The data version", StringConverter.IDENTITY, Optionality.OPTIONAL, "unknown");
+    public static final Switch<String> EDGE_CONFIGURATION = new Switch<>("edgeConfiguration",
+            "The path to the configuration file that defines what OSM Way becomes an Edge",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<String> WAY_SECTIONING_CONFIGURATION = new Switch<>(
+            "waySectioningConfiguration",
+            "The path to the configuration file that defines where to section Ways to make Edges.",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<String> PBF_WAY_CONFIGURATION = new Switch<>(
+            "osmPbfWayConfiguration",
+            "The path to the configuration file that defines which PBF Ways becomes an Atlas Entity.",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<String> PBF_NODE_CONFIGURATION = new Switch<>(
+            "osmPbfNodeConfiguration",
+            "The path to the configuration file that defines which PBF Nodes becomes an Atlas Entity.",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<String> PBF_RELATION_CONFIGURATION = new Switch<>(
+            "osmPbfRelationConfiguration",
+            "The path to the configuration file that defines which PBF Relations becomes an Atlas Entity",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<String> SHOULD_ALWAYS_SLICE_CONFIGURATION = new Switch<>(
+            "shouldAlwaysSliceConfiguration",
+            "The path to the configuration file that defines which entities on which country slicing will"
+                    + " always be attempted regardless of the number of countries it intersects according to the"
+                    + " country boundary map's grid index.",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<Boolean> USE_JAVA_FORMAT = new Switch<>("useJavaFormat",
+            "Generate the atlas files using the java serialization atlas format (as opposed to the protobuf format).",
+            Boolean::parseBoolean, Optionality.OPTIONAL, "false");
+
+    public static StandardConfiguration getStandardConfigurationFrom(
+            final Resource configurationResource)
+    {
+        return new StandardConfiguration(configurationResource);
+    }
+
+    public static ConfiguredTaggableFilter getTaggableFilterFrom(
+            final Resource configurationResource)
+    {
+        return new ConfiguredTaggableFilter(getStandardConfigurationFrom(configurationResource));
+    }
+
+    protected static AtlasLoadingOption buildAtlasLoadingOption(final CountryBoundaryMap boundaries,
+            final Map<String, String> properties)
+    {
+        final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption
+                .createOptionWithAllEnabled(boundaries);
+
+        // Apply all configurations
+        final String edgeConfiguration = properties.get(EDGE_CONFIGURATION.getName());
+        if (edgeConfiguration != null)
+        {
+            atlasLoadingOption
+                    .setEdgeFilter(getTaggableFilterFrom(new StringResource(edgeConfiguration)));
+        }
+
+        final String waySectioningConfiguration = properties
+                .get(WAY_SECTIONING_CONFIGURATION.getName());
+        if (waySectioningConfiguration != null)
+        {
+            atlasLoadingOption.setWaySectionFilter(
+                    getTaggableFilterFrom(new StringResource(waySectioningConfiguration)));
+        }
+
+        final String pbfNodeConfiguration = properties.get(PBF_NODE_CONFIGURATION.getName());
+        if (pbfNodeConfiguration != null)
+        {
+            atlasLoadingOption.setOsmPbfNodeFilter(
+                    getTaggableFilterFrom(new StringResource(pbfNodeConfiguration)));
+        }
+
+        final String pbfWayConfiguration = properties.get(PBF_WAY_CONFIGURATION.getName());
+        if (pbfWayConfiguration != null)
+        {
+            atlasLoadingOption.setOsmPbfWayFilter(
+                    getTaggableFilterFrom(new StringResource(pbfWayConfiguration)));
+        }
+
+        final String pbfRelationConfiguration = properties
+                .get(PBF_RELATION_CONFIGURATION.getName());
+        if (pbfRelationConfiguration != null)
+        {
+            atlasLoadingOption.setOsmPbfRelationFilter(
+                    getTaggableFilterFrom(new StringResource(pbfRelationConfiguration)));
+        }
+
+        return atlasLoadingOption;
+    }
+
+    protected static Map<String, String> extractAtlasLoadingProperties(final CommandMap command,
+            final Map<String, String> sparkContext)
+    {
+        final Map<String, String> propertyMap = new HashMap<>();
+        propertyMap.put(CODE_VERSION.getName(), (String) command.get(CODE_VERSION));
+        propertyMap.put(DATA_VERSION.getName(), (String) command.get(DATA_VERSION));
+
+        final String edgeConfiguration = (String) command.get(EDGE_CONFIGURATION);
+        propertyMap.put(EDGE_CONFIGURATION.getName(), edgeConfiguration == null ? null
+                : FileSystemHelper.resource(edgeConfiguration, sparkContext).all());
+
+        final String waySectioningConfiguration = (String) command
+                .get(WAY_SECTIONING_CONFIGURATION);
+        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null
+                ? null
+                : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
+
+        final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
+        propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
+                : FileSystemHelper.resource(pbfNodeConfiguration, sparkContext).all());
+
+        final String pbfWayConfiguration = (String) command.get(PBF_WAY_CONFIGURATION);
+        propertyMap.put(PBF_WAY_CONFIGURATION.getName(), pbfWayConfiguration == null ? null
+                : FileSystemHelper.resource(pbfWayConfiguration, sparkContext).all());
+
+        final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
+        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
+                pbfRelationConfiguration == null ? null
+                        : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
+
+        return propertyMap;
+    }
+
+    protected static SwitchList switches()
+    {
+        return new SwitchList().with(COUNTRIES, COUNTRY_SHAPES, SHARDING_TYPE, PBF_PATH, PBF_SCHEME,
+                PBF_SHARDING, PREVIOUS_OUTPUT_FOR_DELTA, CODE_VERSION, DATA_VERSION,
+                EDGE_CONFIGURATION, WAY_SECTIONING_CONFIGURATION, PBF_NODE_CONFIGURATION,
+                PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, ATLAS_SCHEME,
+                SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT);
+    }
+
+    private AtlasGeneratorParameters()
+    {
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -158,8 +158,7 @@ public final class AtlasGeneratorParameters
         final String waySectioningConfiguration = (String) command
                 .get(WAY_SECTIONING_CONFIGURATION);
         propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null
-                ? null
-                : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
+                ? null : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
 
         final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
         propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
@@ -170,9 +169,8 @@ public final class AtlasGeneratorParameters
                 : FileSystemHelper.resource(pbfWayConfiguration, sparkContext).all());
 
         final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
-        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
-                pbfRelationConfiguration == null ? null
-                        : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
+        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null
+                ? null : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
 
         return propertyMap;
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -14,7 +14,7 @@ import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.utilities.caching.ConcurrentResourceCache;
-import org.openstreetmap.atlas.utilities.caching.strategies.SystemTemporaryFileCachingStrategy;
+import org.openstreetmap.atlas.utilities.caching.strategies.NamespaceCachingStrategy;
 
 /**
  * Cache an atlas file stored in the standard way (parentpath/COUNTRY/COUNTRY_z-x-y.atlas) to a
@@ -39,8 +39,8 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
     public HadoopAtlasFileCache(final String parentAtlasPath,
             final Map<String, String> configuration)
     {
-        super(new SystemTemporaryFileCachingStrategy(),
-                uri -> FileSystemHelper.resource(uri.toString(), configuration));
+        super(new NamespaceCachingStrategy("HadoopAtlasFileCache"), uri -> Optional
+                .ofNullable(FileSystemHelper.resource(uri.toString(), configuration)));
         this.parentAtlasPath = parentAtlasPath;
         this.atlasScheme = AtlasGeneratorParameters.ATLAS_SCHEME.getDefault();
     }
@@ -58,8 +58,8 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
     public HadoopAtlasFileCache(final String parentAtlasPath,
             final SlippyTilePersistenceScheme atlasScheme, final Map<String, String> configuration)
     {
-        super(new SystemTemporaryFileCachingStrategy(),
-                uri -> FileSystemHelper.resource(uri.toString(), configuration));
+        super(new NamespaceCachingStrategy("HadoopAtlasFileCache"), uri -> Optional
+                .ofNullable(FileSystemHelper.resource(uri.toString(), configuration)));
         this.parentAtlasPath = parentAtlasPath;
         this.atlasScheme = atlasScheme;
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -6,8 +6,10 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
 import org.openstreetmap.atlas.geography.sharding.Shard;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.utilities.caching.ConcurrentResourceCache;
@@ -27,21 +29,25 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
     private static final Logger logger = LoggerFactory.getLogger(HadoopAtlasFileCache.class);
 
     private final String parentAtlasPath;
+    private final SlippyTilePersistenceScheme atlasScheme;
 
     /**
      * Create a new cache.
      *
      * @param parentAtlasPath
      *            The parent path to the atlas files. This might look like hdfs://some/path/to/files
+     * @param atlasScheme
+     *            The scheme used to locate atlas files based on slippy tiles
      * @param configuration
      *            The configuration map
      */
     public HadoopAtlasFileCache(final String parentAtlasPath,
-            final Map<String, String> configuration)
+            final SlippyTilePersistenceScheme atlasScheme, final Map<String, String> configuration)
     {
         super(new SystemTemporaryFileCachingStrategy(),
                 uri -> FileSystemHelper.resource(uri.toString(), configuration));
         this.parentAtlasPath = parentAtlasPath;
+        this.atlasScheme = atlasScheme;
     }
 
     /**
@@ -55,9 +61,14 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
      */
     public Optional<Resource> get(final String country, final Shard shard)
     {
+        String compiledAtlasScheme = "";
+        if (shard instanceof SlippyTile)
+        {
+            compiledAtlasScheme = this.atlasScheme.compile((SlippyTile) shard);
+        }
         final String atlasName = String.format("%s_%s", country, shard.getName());
-        final String atlasURIString = this.parentAtlasPath + "/" + country + "/" + atlasName
-                + FileSuffix.ATLAS.toString();
+        final String atlasURIString = this.parentAtlasPath + "/" + country + "/"
+                + compiledAtlasScheme + atlasName + FileSuffix.ATLAS.toString();
         final URI atlasURI;
 
         try

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.AtlasGeneratorParameters;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
 import org.openstreetmap.atlas.geography.sharding.Shard;
@@ -14,8 +15,6 @@ import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.utilities.caching.ConcurrentResourceCache;
 import org.openstreetmap.atlas.utilities.caching.strategies.SystemTemporaryFileCachingStrategy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Cache an atlas file stored in the standard way (parentpath/COUNTRY/COUNTRY_z-x-y.atlas) to a
@@ -26,10 +25,25 @@ import org.slf4j.LoggerFactory;
  */
 public class HadoopAtlasFileCache extends ConcurrentResourceCache
 {
-    private static final Logger logger = LoggerFactory.getLogger(HadoopAtlasFileCache.class);
-
     private final String parentAtlasPath;
     private final SlippyTilePersistenceScheme atlasScheme;
+
+    /**
+     * Create a new cache.
+     *
+     * @param parentAtlasPath
+     *            The parent path to the atlas files. This might look like hdfs://some/path/to/files
+     * @param configuration
+     *            The configuration map
+     */
+    public HadoopAtlasFileCache(final String parentAtlasPath,
+            final Map<String, String> configuration)
+    {
+        super(new SystemTemporaryFileCachingStrategy(),
+                uri -> FileSystemHelper.resource(uri.toString(), configuration));
+        this.parentAtlasPath = parentAtlasPath;
+        this.atlasScheme = AtlasGeneratorParameters.ATLAS_SCHEME.getDefault();
+    }
 
     /**
      * Create a new cache.

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -14,7 +14,7 @@ import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.utilities.caching.ConcurrentResourceCache;
-import org.openstreetmap.atlas.utilities.caching.strategies.NamespaceCachingStrategy;
+import org.openstreetmap.atlas.utilities.caching.strategies.GlobalNamespaceCachingStrategy;
 
 /**
  * Cache an atlas file stored in the standard way (parentpath/COUNTRY/COUNTRY_z-x-y.atlas) to a
@@ -39,7 +39,7 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
     public HadoopAtlasFileCache(final String parentAtlasPath,
             final Map<String, String> configuration)
     {
-        super(new NamespaceCachingStrategy("HadoopAtlasFileCache"), uri -> Optional
+        super(new GlobalNamespaceCachingStrategy(), uri -> Optional
                 .ofNullable(FileSystemHelper.resource(uri.toString(), configuration)));
         this.parentAtlasPath = parentAtlasPath;
         this.atlasScheme = AtlasGeneratorParameters.ATLAS_SCHEME.getDefault();
@@ -58,7 +58,7 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
     public HadoopAtlasFileCache(final String parentAtlasPath,
             final SlippyTilePersistenceScheme atlasScheme, final Map<String, String> configuration)
     {
-        super(new NamespaceCachingStrategy("HadoopAtlasFileCache"), uri -> Optional
+        super(new GlobalNamespaceCachingStrategy(), uri -> Optional
                 .ofNullable(FileSystemHelper.resource(uri.toString(), configuration)));
         this.parentAtlasPath = parentAtlasPath;
         this.atlasScheme = atlasScheme;

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
@@ -104,8 +104,9 @@ public class ResourceFileSystem extends FileSystem
         {
             delete(hadoopPath, false);
         }
-        final WritableResource resource = new ByteArrayResource();
-        STORE.put(hadoopPath.toString(), resource);
+        final String name = hadoopPath.toString();
+        final WritableResource resource = new ByteArrayResource().withName(name);
+        STORE.put(name, resource);
         return new FSDataOutputStream(resource.write(), STATISTICS);
     }
 
@@ -178,7 +179,8 @@ public class ResourceFileSystem extends FileSystem
     @Override
     public FSDataInputStream open(final Path hadoopPath, final int bufferSize) throws IOException
     {
-        final Resource resource = STORE.get(hadoopPath.toString());
+        final String name = hadoopPath.toString();
+        final Resource resource = STORE.get(name);
         if (resource == null)
         {
             return null;

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/SeekableResourceStream.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/SeekableResourceStream.java
@@ -79,6 +79,7 @@ public class SeekableResourceStream extends InputStream implements Seekable, Pos
     @Override
     public void seek(final long pos) throws IOException
     {
+        // Do not seek, this is for testing only.
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import org.openstreetmap.atlas.generator.AtlasGeneratorHelper;
+import org.openstreetmap.atlas.generator.AtlasGeneratorParameters;
 import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Rectangle;
@@ -87,6 +87,11 @@ public class WorldAtlasGenerator extends Command
         new WorldAtlasGenerator().run(args);
     }
 
+    public static void setHadoopFileSystemConfiguration(final Map<String, String> newConfiguration)
+    {
+        configuration = newConfiguration;
+    }
+
     private static Resource openResource(final String value)
     {
         return FileSystemHelper.resource(value, configuration);
@@ -95,11 +100,6 @@ public class WorldAtlasGenerator extends Command
     private static WritableResource openWritableResource(final String value)
     {
         return FileSystemHelper.writableResource(value, configuration);
-    }
-
-    public void setHadoopFileSystemConfiguration(final Map<String, String> configuration)
-    {
-        this.configuration = configuration;
     }
 
     @Override
@@ -123,9 +123,16 @@ public class WorldAtlasGenerator extends Command
         final Shard world = SlippyTile.ROOT;
         final String forceSlicingConfiguration = (String) command
                 .get(SHOULD_ALWAYS_SLICE_CONFIGURATION);
-        final Predicate<Taggable> forceSlicingPredicate = forceSlicingConfiguration == null
-                ? taggable -> false
-                : AtlasGeneratorHelper.getTaggableFilterFrom(new File(forceSlicingConfiguration));
+        final Predicate<Taggable> forceSlicingPredicate;
+        if (forceSlicingConfiguration == null)
+        {
+            forceSlicingPredicate = taggable -> false;
+        }
+        else
+        {
+            forceSlicingPredicate = AtlasGeneratorParameters
+                    .getTaggableFilterFrom(new File(forceSlicingConfiguration));
+        }
         countryBoundaryMap.setShouldAlwaysSlicePredicate(forceSlicingPredicate);
 
         final Time start = Time.now();

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -11,12 +11,12 @@ log4j.logger.org.reflections=WARN
 
 # Show our logs
 log4j.logger.org.openstreetmap.atlas=TRACE
-log4j.logger.org.openstreetmap.atlas.utilities=DEBUG
+log4j.logger.org.openstreetmap.atlas.utilities=INFO
 log4j.logger.org.openstreetmap.atlas.streaming.resource=INFO
 log4j.logger.org.openstreetmap.atlas.geography.atlas.items.complex.bignode=DEBUG
 log4j.logger.org.openstreetmap.atlas.geography.atlas.items.TurnRestriction=DEBUG
 log4j.logger.org.openstreetmap.atlas.geography.atlas.pbf=INFO
-log4j.logger.org.openstreetmap.atlas.geography.atlas.packed=DEBUG
+log4j.logger.org.openstreetmap.atlas.geography.atlas.packed=INFO
 log4j.logger.org.openstreetmap.atlas.geography.atlas.delta=INFO
 log4j.logger.org.openstreetmap.atlas.geography.atlas.multi.MultiAtlasBorderFixer=INFO
 log4j.logger.org.openstreetmap.atlas.tags=INFO

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -11,12 +11,12 @@ log4j.logger.org.reflections=WARN
 
 # Show our logs
 log4j.logger.org.openstreetmap.atlas=TRACE
-log4j.logger.org.openstreetmap.atlas.utilities=INFO
+log4j.logger.org.openstreetmap.atlas.utilities=DEBUG
 log4j.logger.org.openstreetmap.atlas.streaming.resource=INFO
 log4j.logger.org.openstreetmap.atlas.geography.atlas.items.complex.bignode=DEBUG
 log4j.logger.org.openstreetmap.atlas.geography.atlas.items.TurnRestriction=DEBUG
 log4j.logger.org.openstreetmap.atlas.geography.atlas.pbf=INFO
-log4j.logger.org.openstreetmap.atlas.geography.atlas.packed=INFO
+log4j.logger.org.openstreetmap.atlas.geography.atlas.packed=DEBUG
 log4j.logger.org.openstreetmap.atlas.geography.atlas.delta=INFO
 log4j.logger.org.openstreetmap.atlas.geography.atlas.multi.MultiAtlasBorderFixer=INFO
 log4j.logger.org.openstreetmap.atlas.tags=INFO

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -4,19 +4,16 @@ import java.util.HashMap;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.generator.AtlasGeneratorParameters;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.Resource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author lcram
  */
 public class HadoopAtlasFileCacheTest
 {
-    private static final Logger logger = LoggerFactory.getLogger(HadoopAtlasFileCacheTest.class);
-
     @Test
     public void testCache()
     {
@@ -26,13 +23,14 @@ public class HadoopAtlasFileCacheTest
         parentAtlasCountry.mkdirs();
         try
         {
-            final File atlas1 = parentAtlasCountry.child("AAA_1-1-1.atlas");
+            final File atlas1 = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
             atlas1.writeAndClose("1");
-            final File atlas2 = parentAtlasCountry.child("AAA_2-2-2.atlas");
+            final File atlas2 = parentAtlasCountry.child("2/AAA_2-2-2.atlas");
             atlas2.writeAndClose("2");
 
             final String path = "file://" + parentAtlas.toString();
-            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(path, new HashMap<>());
+            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(path,
+                    AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
 
             // cache miss, this will create the cached copy
             final Resource resource1 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();


### PR DESCRIPTION
### Description:

This PR removes references to the older Atlas generation straight from PBF. It now defaults to the RawAtlas, and the option to roll back to the older one disappears.
Also:
- Create `AtlasGeneratorParameters` to reduce complexity. This one does just Switch definition and configuration building.
- Enable Atlas scheme (the configurable file path with which Atlas files are saved) which did not work with RawAtlas. It did only work with an empty scheme.
- Depend on Atlas 5.2.3, to benefit from the latest caching improvements: https://github.com/osmlab/atlas/pull/258

### Potential Impact:

Non Raw atlas builds will be impossible.

### Unit Test Approach:

- Used existing tests
- Fixed AtlasGeneratorIntegrationTest to use the raw atlas folder scheme
- Updated HadoopAtlasFileCache to be aware of the atlas folder scheme

### Test Results:

DNM until large scale test validates it works.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)