### PR TITLE
Updates to HadoopAtlasFileCache

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -28,34 +28,24 @@ import org.slf4j.LoggerFactory;
  * For example, consider the following code:
  * <p>
  * <code>
- * ResourceCache cache1 = new HadoopAtlasFileCache(parentPath, &quotnamespace1&quot;, config);
+ * ResourceCache cache1 = new HadoopAtlasFileCache(parentPath, "namespace1", config);<br>
+ * ResourceCache cache2 = new HadoopAtlasFileCache(parentPath, "namespace2", config);<br>
  * <br>
- * ResourceCache cache2 = new HadoopAtlasFileCache(parentPath, &quotnamespace2&quot;, config);
- * <br><br>
- * // We will be fetching resource behind URI "parentPath/AAA/AAA_1-1-1.atlas"
+ * // We will be fetching resource behind URI "parentPath/AAA/AAA_1-1-1.atlas"<br>
+ * Resource r1 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();<br>
+ * // Assume some event changes the contents behind the URI between get() calls<br>
+ * Resource r2 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();<br>
  * <br>
- * Resource r1 = cache1.get(&quotAAA&quot;, new SlippyTile(1, 1, 1)).get();
+ * // This fails since the caches have different namespaces and the resource contents changed<br>
+ * Assert.assertEquals(r1.all(), r2.all());<br>
  * <br>
- * // Assume some event changes the contents behind the URI between get() calls
+ * // Now we invalidate cache1's copy of the resource<br>
+ * cache1.invalidate(getURIForResource(r1));<br>
+ * // This call to cache1.get() will re-fetch since we invalidated<br>
+ * r1 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();<br>
  * <br>
- * Resource r2 = cache1.get(&quotAAA&quot;, new SlippyTile(1, 1, 1)).get();
- * <br><br>
- * // This fails since the caches have different namespaces and the resource contents changed
- * <br>
- * Assert.assertEquals(r1.all(), r2.all());
- * <br><br>
- * // Now we invalidate cache1's copy of the resource
- * <br>
- * cache1.invalidate(getURIForResource(r1));
- * <br>
- * // This call to cache1.get() will re-fetch since we invalidated
- * <br>
- * r1 = cache1.get(&quotAAA&quot;, new SlippyTile(1, 1, 1)).get();
- * <br><br>
- * // Now this passes since cache1 was refreshed
- * <br>
- * Assert.assertEquals(r1.all(), r2.all());
- * <br>
+ * // Now this passes since cache1 was refreshed<br>
+ * Assert.assertEquals(r1.all(), r2.all());<br>
  * </code>
  * <p>
  * The key takeaway here is that <code>r1</code> and <code>r2</code> are not guaranteed to have the

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -126,6 +126,7 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
             compiledAtlasScheme = this.atlasScheme.compile((SlippyTile) shard);
         }
         final String atlasName = String.format("%s_%s", country, shard.getName());
+        // TODO it may be preferable to use SparkFileHelper.combine() here
         final String atlasURIString = this.parentAtlasPath + "/" + country + "/"
                 + compiledAtlasScheme + atlasName + FileSuffix.ATLAS.toString();
         final URI atlasURI;

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemHelper.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.generator.tools.filesystem;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,6 +61,39 @@ public final class FileSystemHelper
         catch (final Exception e)
         {
             throw new CoreException("Unable to delete {}", path, e);
+        }
+    }
+
+    /**
+     * Check if the given path exists.
+     *
+     * @param path
+     *            The path to check
+     * @return If the given path exists
+     */
+    public static boolean exists(final String path)
+    {
+        return exists(path, DEFAULT);
+    }
+
+    /**
+     * Check if the given path exists.
+     *
+     * @param path
+     *            The path to check
+     * @param configuration
+     *            The configuration map
+     * @return If the given path exists
+     */
+    public static boolean exists(final String path, final Map<String, String> configuration)
+    {
+        try
+        {
+            return new FileSystemCreator().get(path, configuration).exists(new Path(path));
+        }
+        catch (final IOException exception)
+        {
+            throw new CoreException("Failed to determine existence of {}", path, exception);
         }
     }
 

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -22,6 +22,7 @@ public class HadoopAtlasFileCacheTest
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");
         final File parentAtlasCountry = new File(parentAtlas + "/AAA");
+        final String fullParentPathURI = "file://" + parentAtlas.toString();
         parentAtlasCountry.mkdirs();
         try
         {
@@ -30,8 +31,7 @@ public class HadoopAtlasFileCacheTest
             final File atlas2 = parentAtlasCountry.child("2/AAA_2-2-2.atlas");
             atlas2.writeAndClose("2");
 
-            final String path = "file://" + parentAtlas.toString();
-            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(path,
+            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(fullParentPathURI,
                     AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
 
             // cache miss, this will create the cached copy
@@ -60,32 +60,30 @@ public class HadoopAtlasFileCacheTest
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");
         final File parentAtlasCountry = new File(parentAtlas + "/AAA");
+        final String fullParentPathURI = "file://" + parentAtlas.toString();
         parentAtlasCountry.mkdirs();
         try
         {
             // set up file for cache1
             File atlasFile = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
-            atlasFile.writeAndClose("1");
-
-            final String path = "file://" + parentAtlas.toString();
+            atlasFile.writeAndClose("version1");
 
             // cache file in cache1 under namespace "namespace1"
-            final HadoopAtlasFileCache cache1 = new HadoopAtlasFileCache(path, "namespace1",
-                    AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+            final HadoopAtlasFileCache cache1 = new HadoopAtlasFileCache(fullParentPathURI,
+                    "namespace1", AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"),
+                    new HashMap<>());
             final Resource resource1 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();
 
             // delete and recreate the same file (with same URI) but with new contents for cache2
             atlasFile.delete();
             atlasFile = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
-            atlasFile.writeAndClose("2");
+            atlasFile.writeAndClose("version2");
 
             // cache the file in cache2 under namespace "namespace2"
-            final HadoopAtlasFileCache cache2 = new HadoopAtlasFileCache(path, "namespace2",
-                    AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+            final HadoopAtlasFileCache cache2 = new HadoopAtlasFileCache(fullParentPathURI,
+                    "namespace2", AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"),
+                    new HashMap<>());
             final Resource resource2 = cache2.get("AAA", new SlippyTile(1, 1, 1)).get();
-
-            // we will totally delete the file, but the caches will now use their cached versions
-            atlasFile.delete();
 
             // the files should be unequal, even though the URIs are the same
             Assert.assertNotEquals(resource1.all(), resource2.all());
@@ -101,8 +99,9 @@ public class HadoopAtlasFileCacheTest
             cache1.invalidate(Paths.get(atlasFile.getPath()).toUri());
 
             // recreate version 2 of the file
+            atlasFile.delete();
             atlasFile = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
-            atlasFile.writeAndClose("2");
+            atlasFile.writeAndClose("version2");
 
             // get version 2 of the file into cache1
             final Resource resource5 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();
@@ -122,14 +121,14 @@ public class HadoopAtlasFileCacheTest
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");
         final File parentAtlasCountry = new File(parentAtlas + "/AAA");
+        final String fullParentPathURI = "file://" + parentAtlas.toString();
         parentAtlasCountry.mkdirs();
         try
         {
             final File atlas1 = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
             atlas1.writeAndClose("1");
 
-            final String path = "file://" + parentAtlas.toString();
-            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(path,
+            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(fullParentPathURI,
                     AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
 
             // this resource does not exist!

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.generator.tools.caching;
 
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Optional;
 
@@ -95,6 +96,19 @@ public class HadoopAtlasFileCacheTest
 
             // the files should still be unequal, even though the URIs are the same
             Assert.assertNotEquals(resource3.all(), resource4.all());
+
+            // delete cache1's cached version of the file
+            cache1.invalidate(Paths.get(atlasFile.getPath()).toUri());
+
+            // recreate version 2 of the file
+            atlasFile = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
+            atlasFile.writeAndClose("2");
+
+            // get version 2 of the file into cache1
+            final Resource resource5 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();
+
+            // now the resources should be identical
+            Assert.assertEquals(resource4.all(), resource5.all());
         }
         finally
         {

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.generator.tools.caching;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,6 +46,81 @@ public class HadoopAtlasFileCacheTest
 
             Assert.assertEquals("1", resource3.firstLine());
             Assert.assertEquals("2", resource4.firstLine());
+        }
+        finally
+        {
+            parent.deleteRecursively();
+        }
+    }
+
+    @Test
+    public void testCachesWithDifferentNamespaces()
+    {
+        final File parent = File.temporaryFolder();
+        final File parentAtlas = new File(parent + "/atlas");
+        final File parentAtlasCountry = new File(parentAtlas + "/AAA");
+        parentAtlasCountry.mkdirs();
+        try
+        {
+            // set up file for cache1
+            File atlasFile = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
+            atlasFile.writeAndClose("1");
+
+            final String path = "file://" + parentAtlas.toString();
+
+            // cache file in cache1 under namespace "namespace1"
+            final HadoopAtlasFileCache cache1 = new HadoopAtlasFileCache(path, "namespace1",
+                    AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+            final Resource resource1 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();
+
+            // delete and recreate the same file (with same URI) but with new contents for cache2
+            atlasFile.delete();
+            atlasFile = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
+            atlasFile.writeAndClose("2");
+
+            // cache the file in cache2 under namespace "namespace2"
+            final HadoopAtlasFileCache cache2 = new HadoopAtlasFileCache(path, "namespace2",
+                    AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+            final Resource resource2 = cache2.get("AAA", new SlippyTile(1, 1, 1)).get();
+
+            // we will totally delete the file, but the caches will now use their cached versions
+            atlasFile.delete();
+
+            // the files should be unequal, even though the URIs are the same
+            Assert.assertNotEquals(resource1.all(), resource2.all());
+
+            // now we are getting the cached versions of the file
+            final Resource resource3 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();
+            final Resource resource4 = cache2.get("AAA", new SlippyTile(1, 1, 1)).get();
+
+            // the files should still be unequal, even though the URIs are the same
+            Assert.assertNotEquals(resource3.all(), resource4.all());
+        }
+        finally
+        {
+            parent.deleteRecursively();
+        }
+    }
+
+    @Test
+    public void testNonexistentResource()
+    {
+        final File parent = File.temporaryFolder();
+        final File parentAtlas = new File(parent + "/atlas");
+        final File parentAtlasCountry = new File(parentAtlas + "/AAA");
+        parentAtlasCountry.mkdirs();
+        try
+        {
+            final File atlas1 = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
+            atlas1.writeAndClose("1");
+
+            final String path = "file://" + parentAtlas.toString();
+            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(path,
+                    AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+
+            // this resource does not exist!
+            final Optional<Resource> resourceOptional = cache.get("AAA", new SlippyTile(5, 5, 5));
+            Assert.assertFalse(resourceOptional.isPresent());
         }
         finally
         {

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -23,6 +23,8 @@ public class HadoopAtlasFileCacheTest
         final File parentAtlas = new File(parent + "/atlas");
         final File parentAtlasCountry = new File(parentAtlas + "/AAA");
         final String fullParentPathURI = "file://" + parentAtlas.toString();
+        final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(fullParentPathURI,
+                AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
         parentAtlasCountry.mkdirs();
         try
         {
@@ -30,9 +32,6 @@ public class HadoopAtlasFileCacheTest
             atlas1.writeAndClose("1");
             final File atlas2 = parentAtlasCountry.child("2/AAA_2-2-2.atlas");
             atlas2.writeAndClose("2");
-
-            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(fullParentPathURI,
-                    AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
 
             // cache miss, this will create the cached copy
             final Resource resource1 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();
@@ -50,6 +49,7 @@ public class HadoopAtlasFileCacheTest
         }
         finally
         {
+            cache.invalidate();
             parent.deleteRecursively();
         }
     }
@@ -61,6 +61,10 @@ public class HadoopAtlasFileCacheTest
         final File parentAtlas = new File(parent + "/atlas");
         final File parentAtlasCountry = new File(parentAtlas + "/AAA");
         final String fullParentPathURI = "file://" + parentAtlas.toString();
+        final HadoopAtlasFileCache cache1 = new HadoopAtlasFileCache(fullParentPathURI,
+                "namespace1", AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+        final HadoopAtlasFileCache cache2 = new HadoopAtlasFileCache(fullParentPathURI,
+                "namespace2", AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
         parentAtlasCountry.mkdirs();
         try
         {
@@ -69,9 +73,6 @@ public class HadoopAtlasFileCacheTest
             atlasFile.writeAndClose("version1");
 
             // cache file in cache1 under namespace "namespace1"
-            final HadoopAtlasFileCache cache1 = new HadoopAtlasFileCache(fullParentPathURI,
-                    "namespace1", AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"),
-                    new HashMap<>());
             final Resource resource1 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();
 
             // delete and recreate the same file (with same URI) but with new contents for cache2
@@ -80,9 +81,6 @@ public class HadoopAtlasFileCacheTest
             atlasFile.writeAndClose("version2");
 
             // cache the file in cache2 under namespace "namespace2"
-            final HadoopAtlasFileCache cache2 = new HadoopAtlasFileCache(fullParentPathURI,
-                    "namespace2", AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"),
-                    new HashMap<>());
             final Resource resource2 = cache2.get("AAA", new SlippyTile(1, 1, 1)).get();
 
             // the files should be unequal, even though the URIs are the same
@@ -111,6 +109,8 @@ public class HadoopAtlasFileCacheTest
         }
         finally
         {
+            cache1.invalidate();
+            cache2.invalidate();
             parent.deleteRecursively();
         }
     }
@@ -122,14 +122,13 @@ public class HadoopAtlasFileCacheTest
         final File parentAtlas = new File(parent + "/atlas");
         final File parentAtlasCountry = new File(parentAtlas + "/AAA");
         final String fullParentPathURI = "file://" + parentAtlas.toString();
+        final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(fullParentPathURI,
+                AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
         parentAtlasCountry.mkdirs();
         try
         {
             final File atlas1 = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
             atlas1.writeAndClose("1");
-
-            final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(fullParentPathURI,
-                    AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
 
             // this resource does not exist!
             final Optional<Resource> resourceOptional = cache.get("AAA", new SlippyTile(5, 5, 5));
@@ -137,6 +136,7 @@ public class HadoopAtlasFileCacheTest
         }
         finally
         {
+            cache.invalidate();
             parent.deleteRecursively();
         }
     }


### PR DESCRIPTION
### Description:

The `HadoopAtlasFileCache` now better handles the case when the requested `Resource` does not exist - returning an empty `Optional` instead of an invalid "timebomb" `Resource` object. Additionally, users can now specify cache namespaces to create logically distinct caches.

```java
HadoopAtlasFileCache cache1 = new HadoopAtlasFileCache(parentPath, "namespace1", config);
HadoopAtlasFileCache cache2 = new HadoopAtlasFileCache(parentPath, "namespace2", config);
HadoopAtlasFileCache anotherCache2 = new HadoopAtlasFileCache(parentPath, "namespace2", config);
// cache1 and cache2 do NOT share their underlying contents
// cache2 and anotherCache2 do share their underlying contents
```

### Potential Impact:

Users of `HadoopAtlasFileCache` will need to be vigilant when unwrapping the returned `Optional`. They will need to explicitly check for the presence of the desired `Resource`.

### Unit Test Approach:

Added unit tests to `HadoopAtlasFileCacheTest`. Of interest are `testNonexistentResource` and `testCachesWithDifferentNamespaces`.

### Test Results:

All tests pass.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)