### PR TITLE
Adding WorldAtlasGenerator edge configuration

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
@@ -59,9 +59,9 @@ public class WorldAtlasGenerator extends Command
             "The code version", StringConverter.IDENTITY, Optionality.OPTIONAL, "unknown");
     public static final Switch<String> DATA_VERSION = new Switch<>("dataVersion",
             "The data version", StringConverter.IDENTITY, Optionality.OPTIONAL, "unknown");
-    public static final Switch<Boolean> USE_RAW_ATLAS = new Switch<>("useRawAtlas",
-            "Allow PBF to Atlas process to use Raw Atlas flow", Boolean::parseBoolean,
-            Optionality.OPTIONAL, "false");
+    public static final Switch<String> EDGE_CONFIGURATION = new Switch<>("edgeConfiguration",
+            "The path to the configuration file that defines what OSM Way becomes an Edge",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<String> SHOULD_ALWAYS_SLICE_CONFIGURATION = new Switch<>(
             "shouldAlwaysSliceConfiguration",
             "The path to the configuration file that defines which entities on which country slicing will"
@@ -115,6 +115,7 @@ public class WorldAtlasGenerator extends Command
                     "AAA||" + Rectangle.MAXIMUM.toWkt());
             countryBoundaryMap = CountryBoundaryMap.fromPlainText(wholeWorld);
         }
+        final File edgeConfiguration = (File) command.get(EDGE_CONFIGURATION);
         final File pbfWayConfiguration = (File) command.get(PBF_WAY_CONFIGURATION);
         final File pbfNodeConfiguration = (File) command.get(PBF_NODE_CONFIGURATION);
         final File pbfRelationConfiguration = (File) command.get(PBF_RELATION_CONFIGURATION);
@@ -144,6 +145,13 @@ public class WorldAtlasGenerator extends Command
         final AtlasLoadingOption loadingOptions = AtlasLoadingOption
                 .createOptionWithAllEnabled(countryBoundaryMap)
                 .setAdditionalCountryCodes(countryBoundaryMap.allCountryNames());
+
+        if (edgeConfiguration != null)
+        {
+            loadingOptions.setEdgeFilter(
+                    new ConfiguredTaggableFilter(new StandardConfiguration(edgeConfiguration)));
+        }
+
         if (pbfWayConfiguration == null)
         {
             loadingOptions.setOsmPbfWayFilter(PBF_NO_FILTER_CONFIGURATION);
@@ -218,8 +226,8 @@ public class WorldAtlasGenerator extends Command
     protected SwitchList switches()
     {
         return new SwitchList().with(PBF, ATLAS, STATISTICS, BOUNDARIES, CODE_VERSION, DATA_VERSION,
-                SHOULD_ALWAYS_SLICE_CONFIGURATION, PBF_WAY_CONFIGURATION, PBF_NODE_CONFIGURATION,
-                PBF_RELATION_CONFIGURATION);
+                EDGE_CONFIGURATION, SHOULD_ALWAYS_SLICE_CONFIGURATION, PBF_WAY_CONFIGURATION,
+                PBF_NODE_CONFIGURATION, PBF_RELATION_CONFIGURATION);
     }
 
 }


### PR DESCRIPTION
### Description:

Adding the ability to specify an edge configuration file when using the `WorldAtlasGenerator`. Also, removing the raw atlas flag, since it was not used and the pbf ingest process already  relies on it by default.

### Potential Impact:

Any users can now pass in a configuration file to specify what becomes an edge when using this generator.

### Unit Test Approach:

N/A

### Test Results:

Integration test passes.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
