### PR TITLE
Added setter for Spark Context in SparkJob

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
@@ -222,6 +222,11 @@ public abstract class SparkJob extends Command implements Serializable
         return 0;
     }
 
+    public void setContext(final JavaSparkContext context)
+    {
+        this.context = context;
+    }
+
     /**
      * The spark Job
      *

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
@@ -222,11 +222,6 @@ public abstract class SparkJob extends Command implements Serializable
         return 0;
     }
 
-    public void setContext(final JavaSparkContext context)
-    {
-        this.context = context;
-    }
-
     /**
      * The spark Job
      *
@@ -321,6 +316,11 @@ public abstract class SparkJob extends Command implements Serializable
     protected Resource resource(final String path)
     {
         return resource(path, configurationMap());
+    }
+
+    protected void setContext(final JavaSparkContext context)
+    {
+        this.context = context;
     }
 
     /**


### PR DESCRIPTION
### Description:

This PR adds a setter for the `JavaSparkContext` within `SparkJob`. This will allow a spark job to instantiate a spark context, and then pass that context to smaller jobs that comprise the larger one.

### Potential Impact:

Will have no downstream impact.

### Unit Test Approach:

N/A

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)