### PR TITLE
Refactored SlippyTilePersistenceScheme and other path code

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.3.1',
+    atlas: '5.3.2',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -16,6 +16,7 @@ import org.apache.spark.broadcast.Broadcast;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.tools.caching.HadoopAtlasFileCache;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
@@ -131,9 +132,9 @@ public final class AtlasGeneratorHelper implements Serializable
             try
             {
                 final Optional<Atlas> alter = new AtlasLocator(sparkContext).atlasForShard(
-                        previousOutputForDelta + "/"
-                                + StringList.split(countryShardName,
-                                        CountryShard.COUNTRY_SHARD_SEPARATOR).get(0),
+                        SparkFileHelper.combine(previousOutputForDelta,
+                                StringList.split(countryShardName,
+                                        CountryShard.COUNTRY_SHARD_SEPARATOR).get(0)),
                         countryShardName);
                 if (alter.isPresent())
                 {

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -34,8 +34,9 @@ public final class AtlasGeneratorParameters
     public static final Switch<String> PBF_PATH = new Switch<>("pbfs", "The path to PBFs",
             StringConverter.IDENTITY, Optionality.REQUIRED);
     public static final Switch<SlippyTilePersistenceScheme> PBF_SCHEME = new Switch<>("pbfScheme",
-            "The folder structure of the PBF", SlippyTilePersistenceScheme::new,
-            Optionality.OPTIONAL, PbfLocator.DEFAULT_SCHEME);
+            "The folder structure of the PBF",
+            SlippyTilePersistenceScheme::getSchemeInstanceFromString, Optionality.OPTIONAL,
+            PbfLocator.DEFAULT_SCHEME);
     public static final Switch<String> PBF_SHARDING = new Switch<>("pbfSharding",
             "The sharding tree of the pbf files. If not specified, this will default to the general Atlas sharding.",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
@@ -43,7 +44,7 @@ public final class AtlasGeneratorParameters
             "atlasScheme",
             "The folder structure of the output Atlas. Example: \"zz/xx/yy/\" or \"\""
                     + " (everything under the same folder)",
-            SlippyTilePersistenceScheme::new, Optionality.OPTIONAL,
+            SlippyTilePersistenceScheme::getSchemeInstanceFromString, Optionality.OPTIONAL,
             AbstractMultipleAtlasBasedOutputFormat.DEFAULT_SCHEME);
     public static final Switch<String> SHARDING_TYPE = new Switch<>("sharding",
             "The sharding definition.", StringConverter.IDENTITY, Optionality.OPTIONAL,

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasLocator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasLocator.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.generator.tools.spark.DataLocator;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
@@ -56,11 +57,12 @@ public class AtlasLocator extends DataLocator<Atlas>
 
     private String fullPath(final String atlasPath, final String countryShard)
     {
-        return atlasPath + "/" + countryShard + FileSuffix.ATLAS;
+        return SparkFileHelper.combine(atlasPath, countryShard + FileSuffix.ATLAS);
     }
 
     private String fullPathGzipped(final String atlasPath, final String countryShard)
     {
-        return atlasPath + "/" + countryShard + FileSuffix.ATLAS + FileSuffix.GZIP;
+        return SparkFileHelper.combine(atlasPath,
+                countryShard + FileSuffix.ATLAS + FileSuffix.GZIP);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/PbfLocator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/PbfLocator.java
@@ -13,6 +13,7 @@ import org.apache.hadoop.fs.Path;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemCreator;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
@@ -87,8 +88,8 @@ public class PbfLocator implements Serializable
                 spark);
         this.pbfFetcher = (Function<SlippyTile, Optional<LocatedPbf>> & Serializable) shard ->
         {
-            final Path pbfName = new Path(this.pbfContext.getPbfPath() + "/"
-                    + this.pbfContext.getScheme().compile(shard));
+            final Path pbfName = new Path(SparkFileHelper.combine(this.pbfContext.getPbfPath(),
+                    this.pbfContext.getScheme().compile(shard)));
             try
             {
                 if (!fileSystem.exists(pbfName))

--- a/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.generator.PbfLoader;
 import org.openstreetmap.atlas.generator.PbfLocator;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.geography.atlas.dynamic.DynamicAtlas;
@@ -122,7 +123,8 @@ public class RawAtlasCreator extends Command
      */
     public static final Switch<String> SLICED_CACHE_PATH = new Switch<>("slicedCache",
             "The path to the sliced atlas cache for DynamicAtlas", StringConverter.IDENTITY,
-            Optionality.OPTIONAL, System.getProperty("user.home") + "/" + DEFAULT_CACHE_NAME);
+            Optionality.OPTIONAL,
+            SparkFileHelper.combine(System.getProperty("user.home"), DEFAULT_CACHE_NAME));
 
     /*
      * If we attempt to populate the sliced atlas cache and still miss, we can optionally fail fast.
@@ -196,8 +198,8 @@ public class RawAtlasCreator extends Command
         final String pbfPath = (String) command.get(PBF_PATH);
         final String slicedCachePath = (String) command.get(SLICED_CACHE_PATH);
         final boolean failFastOnSlicedCacheMiss = (boolean) command.get(FAIL_FAST_CACHE_MISS);
-        final SlippyTilePersistenceScheme pbfScheme = new SlippyTilePersistenceScheme(
-                PbfLocator.DEFAULT_SCHEME);
+        final SlippyTilePersistenceScheme pbfScheme = SlippyTilePersistenceScheme
+                .getSchemeInstanceFromString(PbfLocator.DEFAULT_SCHEME);
         final String pbfShardingName = (String) command.get(PBF_SHARDING);
         final String shardingName = (String) command.get(SHARDING_TYPE);
         final Sharding sharding = AtlasSharding.forString(shardingName, Maps.stringMap());

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/AbstractMultipleAtlasBasedOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/AbstractMultipleAtlasBasedOutputFormat.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.generator.persistence;
 import org.apache.hadoop.mapred.lib.MultipleOutputFormat;
 import org.openstreetmap.atlas.generator.AtlasGenerator;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.geography.sharding.CountryShard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.geography.sharding.converters.SlippyTileConverter;
@@ -30,10 +31,10 @@ public abstract class AbstractMultipleAtlasBasedOutputFormat<Type>
         final String country = countrySplit.get(0);
         final String shard = countrySplit.get(1);
         final String schemeDefinition = countrySplit.size() > 2 ? countrySplit.get(2) : "";
-        final SlippyTilePersistenceScheme scheme = new SlippyTilePersistenceScheme(
-                schemeDefinition);
+        final SlippyTilePersistenceScheme scheme = SlippyTilePersistenceScheme
+                .getSchemeInstanceFromString(schemeDefinition);
         final SlippyTile slippyTile = new SlippyTileConverter().backwardConvert(shard);
-        return country + "/" + scheme.compile(slippyTile) + country
-                + CountryShard.COUNTRY_SHARD_SEPARATOR + shard;
+        return SparkFileHelper.combine(country, scheme.compile(slippyTile),
+                country + CountryShard.COUNTRY_SHARD_SEPARATOR + shard);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/scheme/SlippyTilePersistenceScheme.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/scheme/SlippyTilePersistenceScheme.java
@@ -3,8 +3,30 @@ package org.openstreetmap.atlas.generator.persistence.scheme;
 import java.io.Serializable;
 
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 
 /**
+ * This class helps users construct storage paths dynamically based on the name of the target
+ * resource to be saved. The various allowed storage schemes are defined in
+ * {@link SlippyTilePersistenceSchemeType}.<br>
+ * <br>
+ * For example, one PBF storage scheme is 'ZZ_XX_YY_SUBFOLDERS_PBF', which is defined as
+ * 'zz/xx/yy/zz-xx-yy.pbf'. This means that when saving the PBF '12-34-48.pbf' to a remote store,
+ * users can easily construct the proper storage path for that PBF (i.e. 12/34/48/12-34-48.pbf) and
+ * use that to save the file. An example usage:<br>
+ * <br>
+ * <code>
+ * // Pbf is tile 12-34-48<br>
+ * // Assume we have some kind of PBF object<br>
+ * Pbf myPbfObject;<br>
+ * SlippyTilePersistenceScheme scheme = new SlippyTilePersistenceScheme(SlippyTilePersistenceSchemeType.ZZ_XX_YY_SUBFOLDERS_PBF);<br>
+ * // OR<br>
+ * SlippyTilePersistenceScheme scheme = SlippyTilePersistenceScheme.getSchemeInstanceFromString("ZZ_XX_YY_SUBFOLDERS_PBF");<br>
+ * WritableResource resource = new File(SparkFileHelper.combine("hdfs://myPBFs", scheme.compile(myPbfObject.getShard())));<br>
+ * myPbfObject.save(resource);<br>
+ * // we now have a PBF saved at "hdfs://myPBFs/12/34/48/12-34-48.pbf"<br>
+ * </code>
+ *
  * @author matthieun
  */
 public class SlippyTilePersistenceScheme implements Serializable
@@ -15,11 +37,34 @@ public class SlippyTilePersistenceScheme implements Serializable
     public static final String X_INDEX = "xx";
     public static final String Y_INDEX = "yy";
 
-    private final String scheme;
+    static final String HYPHEN = "-";
 
-    public SlippyTilePersistenceScheme(final String scheme)
+    private final String scheme;
+    private final FileSuffix suffix;
+
+    public static SlippyTilePersistenceScheme getSchemeInstanceFromString(final String string)
     {
-        this.scheme = scheme;
+        SlippyTilePersistenceSchemeType type;
+
+        /*
+         * Backwards compatibility hack: for now, allow this class to parse any old scheme strings
+         * still found in the wild. Ideally, downstream users should migrate calling code to use the
+         * scheme enum names instead of arbitrary scheme strings. E.G. users should use the scheme
+         * enum name 'ZZ_XX_YY_PBF' as opposed to the actual scheme string, which is 'zz-xx-yy.pbf'.
+         */
+        type = SlippyTilePersistenceSchemeType.legacyArbitrarySchemeToSchemeType(string);
+
+        if (type == null)
+        {
+            type = SlippyTilePersistenceSchemeType.enumNameToSchemeType(string);
+        }
+        return new SlippyTilePersistenceScheme(type);
+    }
+
+    public SlippyTilePersistenceScheme(final SlippyTilePersistenceSchemeType type)
+    {
+        this.scheme = type.getValue();
+        this.suffix = type.getSuffix();
     }
 
     public String compile(final SlippyTile tile)
@@ -32,11 +77,11 @@ public class SlippyTilePersistenceScheme implements Serializable
     {
         return this.scheme.replaceAll(ZOOM, String.valueOf(zoom))
                 .replaceAll(X_INDEX, String.valueOf(xIndex))
-                .replaceAll(Y_INDEX, String.valueOf(yIndex));
+                .replaceAll(Y_INDEX, String.valueOf(yIndex)) + this.suffix;
     }
 
     public String getScheme()
     {
-        return this.scheme;
+        return this.scheme + this.suffix;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/scheme/SlippyTilePersistenceSchemeType.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/scheme/SlippyTilePersistenceSchemeType.java
@@ -1,0 +1,131 @@
+package org.openstreetmap.atlas.generator.persistence.scheme;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+
+/**
+ * Definitions for various types of {@link SlippyTilePersistenceScheme}s. This enum forces users of
+ * {@link SlippyTilePersistenceScheme} into some predefined schemes, instead of allowing totally
+ * custom schemes. This should help mitigate gotchas surrounding path construction and other
+ * implementation details. Schemes may or may not contain a terminating file extension. In the case
+ * that the file extension is {@link FileSuffix} NONE, then the scheme can be thought of as a
+ * directory scheme. If the {@link FileSuffix} is provided, then the scheme will represent a
+ * terminated path (i.e.) a path containing a terminating file.
+ *
+ * @author lcram
+ */
+public enum SlippyTilePersistenceSchemeType
+{
+    // zz-xx-yy.pbf
+    ZZ_XX_YY_PBF(
+            SlippyTilePersistenceScheme.ZOOM + SlippyTilePersistenceScheme.HYPHEN
+                    + SlippyTilePersistenceScheme.X_INDEX + SlippyTilePersistenceScheme.HYPHEN
+                    + SlippyTilePersistenceScheme.Y_INDEX,
+            FileSuffix.PBF),
+
+    // zz/xx-yy.pbf
+    ZZ_SLASH_XX_YY_PBF(
+            SparkFileHelper.combine(SlippyTilePersistenceScheme.ZOOM,
+                    SlippyTilePersistenceScheme.X_INDEX + SlippyTilePersistenceScheme.HYPHEN
+                            + SlippyTilePersistenceScheme.Y_INDEX),
+            FileSuffix.PBF),
+
+    // zz/xx/yy/zz-xx-yy.pf
+    ZZ_XX_YY_SUBFOLDERS_PBF(
+            SparkFileHelper.combine(SlippyTilePersistenceScheme.ZOOM,
+                    SlippyTilePersistenceScheme.X_INDEX, SlippyTilePersistenceScheme.Y_INDEX,
+                    SlippyTilePersistenceScheme.ZOOM + SlippyTilePersistenceScheme.HYPHEN
+                            + SlippyTilePersistenceScheme.X_INDEX
+                            + SlippyTilePersistenceScheme.HYPHEN
+                            + SlippyTilePersistenceScheme.Y_INDEX),
+            FileSuffix.PBF),
+
+    // zz-xx-yy.osm.pbf
+    ZZ_XX_YY_OSMPBF(
+            SlippyTilePersistenceScheme.ZOOM + SlippyTilePersistenceScheme.HYPHEN
+                    + SlippyTilePersistenceScheme.X_INDEX + SlippyTilePersistenceScheme.HYPHEN
+                    + SlippyTilePersistenceScheme.Y_INDEX,
+            FileSuffix.OSMPBF),
+
+    // zz/xx-yy.osm.pbf
+    ZZ_SLASH_XX_YY_OSMPBF(
+            SparkFileHelper.combine(SlippyTilePersistenceScheme.ZOOM,
+                    SlippyTilePersistenceScheme.X_INDEX + SlippyTilePersistenceScheme.HYPHEN
+                            + SlippyTilePersistenceScheme.Y_INDEX),
+            FileSuffix.OSMPBF),
+
+    // zz/zz-xx-yy.osm.pbf
+    ZZ_SLASH_ZZ_XX_YY_OSMPBF(
+            SparkFileHelper.combine(SlippyTilePersistenceScheme.ZOOM,
+                    SlippyTilePersistenceScheme.ZOOM + SlippyTilePersistenceScheme.HYPHEN
+                            + SlippyTilePersistenceScheme.X_INDEX
+                            + SlippyTilePersistenceScheme.HYPHEN
+                            + SlippyTilePersistenceScheme.Y_INDEX),
+            FileSuffix.OSMPBF),
+
+    // zz/xx/yy/zz-xx-yy.osm.pbf
+    ZZ_XX_YY_SUBFOLDERS_OSMPBF(
+            SparkFileHelper.combine(SlippyTilePersistenceScheme.ZOOM,
+                    SlippyTilePersistenceScheme.X_INDEX, SlippyTilePersistenceScheme.Y_INDEX,
+                    SlippyTilePersistenceScheme.ZOOM + SlippyTilePersistenceScheme.HYPHEN
+                            + SlippyTilePersistenceScheme.X_INDEX
+                            + SlippyTilePersistenceScheme.HYPHEN
+                            + SlippyTilePersistenceScheme.Y_INDEX),
+            FileSuffix.OSMPBF),
+
+    // zz/
+    // NOTE: this is a hack, it does NOT use SparkFileHelper.combine(), since the combine() method
+    // filters empty path components. However, there are lots of "zz/" in the wild, so we must
+    // support it here using a hardcoded "/"
+    ZZ_SUBFOLDER(SlippyTilePersistenceScheme.ZOOM + "/", FileSuffix.NONE),
+
+    EMPTY("", FileSuffix.NONE);
+
+    private String value;
+
+    private FileSuffix suffix;
+
+    static SlippyTilePersistenceSchemeType enumNameToSchemeType(final String string)
+    {
+        for (final SlippyTilePersistenceSchemeType type : SlippyTilePersistenceSchemeType.values())
+        {
+            // Try matching by enum name
+            if (type.name().equalsIgnoreCase(string))
+            {
+                return type;
+            }
+        }
+        throw new CoreException("Invalid SlippyTilePersistenceSchemeType name {}", string);
+    }
+
+    static SlippyTilePersistenceSchemeType legacyArbitrarySchemeToSchemeType(final String string)
+    {
+        for (final SlippyTilePersistenceSchemeType type : SlippyTilePersistenceSchemeType.values())
+        {
+            // Try matching by the scheme string
+            final String schemeString = type.getValue() + type.getSuffix().toString();
+            if (schemeString.equals(string))
+            {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    SlippyTilePersistenceSchemeType(final String value, final FileSuffix suffix)
+    {
+        this.value = value;
+        this.suffix = suffix;
+    }
+
+    public FileSuffix getSuffix()
+    {
+        return this.suffix;
+    }
+
+    public String getValue()
+    {
+        return this.value;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCache.java
@@ -9,6 +9,7 @@ import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.AtlasGeneratorParameters;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
@@ -180,8 +181,8 @@ public class HadoopAtlasFileCache extends ConcurrentResourceCache
         }
         final String atlasName = String.format("%s_%s", country, shard.getName());
 
-        final String atlasURIString = this.parentAtlasPath + "/" + country + "/"
-                + compiledAtlasScheme + atlasName + FileSuffix.ATLAS.toString();
+        final String atlasURIString = SparkFileHelper.combine(this.parentAtlasPath, country,
+                compiledAtlasScheme, atlasName + FileSuffix.ATLAS.toString());
 
         final URI atlasURI;
         try

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
@@ -28,7 +28,6 @@ import org.openstreetmap.atlas.generator.tools.spark.context.SparkContextProvide
 import org.openstreetmap.atlas.generator.tools.spark.context.SparkContextProviderFinder;
 import org.openstreetmap.atlas.generator.tools.spark.converters.SparkOptionsStringConverter;
 import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
-import org.openstreetmap.atlas.streaming.Streams;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.AbstractResource;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
@@ -426,11 +425,11 @@ public abstract class SparkJob extends Command implements Serializable
         try
         {
             final FileSystem fileSystem = getFileSystem(path);
-            final BufferedWriter out = new BufferedWriter(new OutputStreamWriter(
-                    fileSystem.create(new Path(SparkFileHelper.combine(path, name)))));
-            // TODO this leaks a resource if write() throws an exception
-            out.write(contents);
-            Streams.close(out);
+            try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(
+                    fileSystem.create(new Path(SparkFileHelper.combine(path, name))))))
+            {
+                out.write(contents);
+            }
         }
         catch (final Exception e)
         {

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
@@ -27,6 +27,7 @@ import org.openstreetmap.atlas.generator.tools.spark.context.DefaultSparkContext
 import org.openstreetmap.atlas.generator.tools.spark.context.SparkContextProvider;
 import org.openstreetmap.atlas.generator.tools.spark.context.SparkContextProviderFinder;
 import org.openstreetmap.atlas.generator.tools.spark.converters.SparkOptionsStringConverter;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.streaming.Streams;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.AbstractResource;
@@ -261,7 +262,7 @@ public abstract class SparkJob extends Command implements Serializable
      */
     protected String getAlternateParallelFolderOutput(final String output, final String name)
     {
-        return output.substring(0, output.lastIndexOf("/")) + "-" + name;
+        return SparkFileHelper.parentPath(output) + "-" + name;
     }
 
     /**
@@ -276,7 +277,7 @@ public abstract class SparkJob extends Command implements Serializable
      */
     protected String getAlternateSubFolderOutput(final String output, final String name)
     {
-        return output.substring(0, output.lastIndexOf("/")) + "/" + name;
+        return SparkFileHelper.combine(SparkFileHelper.parentPath(output), name);
     }
 
     protected JavaSparkContext getContext()
@@ -379,7 +380,7 @@ public abstract class SparkJob extends Command implements Serializable
             final FileSystem fileSystem = getFileSystem(path);
             try
             {
-                fileSystem.getFileStatus(new Path(path + "/" + name));
+                fileSystem.getFileStatus(new Path(SparkFileHelper.combine(path, name)));
                 fileIsThere = true;
             }
             catch (final FileNotFoundException e)
@@ -412,7 +413,7 @@ public abstract class SparkJob extends Command implements Serializable
 
     private void deleteStatus(final String path, final String name)
     {
-        deleteStatus(path + "/" + name);
+        deleteStatus(SparkFileHelper.combine(path, name));
     }
 
     private FileSystem getFileSystem(final String path) throws IllegalArgumentException, IOException
@@ -425,8 +426,9 @@ public abstract class SparkJob extends Command implements Serializable
         try
         {
             final FileSystem fileSystem = getFileSystem(path);
-            final BufferedWriter out = new BufferedWriter(
-                    new OutputStreamWriter(fileSystem.create(new Path(path + "/" + name))));
+            final BufferedWriter out = new BufferedWriter(new OutputStreamWriter(
+                    fileSystem.create(new Path(SparkFileHelper.combine(path, name)))));
+            // TODO this leaks a resource if write() throws an exception
             out.write(contents);
             Streams.close(out);
         }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
@@ -70,8 +70,12 @@ public class SparkFileHelper implements Serializable
         final StringBuilder builder = new StringBuilder(pathNotEndingWithSeparator(basePath));
         for (final String path : paths)
         {
+            if (path.isEmpty())
+            {
+                continue;
+            }
             builder.append(DIRECTORY_SEPARATOR);
-            builder.append(pathNotStartingWithSeparator(path));
+            builder.append(pathNotStartingOrEndingWithSeparator(path));
         }
 
         return builder.toString();
@@ -126,6 +130,11 @@ public class SparkFileHelper implements Serializable
         return pathNotEndingWithSeparator(path, DIRECTORY_SEPARATOR);
     }
 
+    public static String pathNotStartingOrEndingWithSeparator(final String path)
+    {
+        return pathNotStartingOrEndingWithSeparator(path, DIRECTORY_SEPARATOR);
+    }
+
     /**
      * Removes {@code PATH_SEPARATOR} from the beginning of given path.
      *
@@ -152,9 +161,28 @@ public class SparkFileHelper implements Serializable
             return EMPTY_STRING;
         }
 
-        final int lastSeparatorIndex = path.lastIndexOf(separator);
-        return lastSeparatorIndex == path.length() - 1 ? path.substring(0, lastSeparatorIndex)
-                : path;
+        String scrubbedPath = path;
+        while (scrubbedPath.lastIndexOf(separator) != -1)
+        {
+            final int lastSeparatorIndex = scrubbedPath.lastIndexOf(separator);
+            if (lastSeparatorIndex == scrubbedPath.length() - 1)
+            {
+                scrubbedPath = scrubbedPath.substring(0, lastSeparatorIndex);
+            }
+            else
+            {
+                break;
+            }
+        }
+        return scrubbedPath;
+    }
+
+    private static String pathNotStartingOrEndingWithSeparator(final String path,
+            final String directorySeparator)
+    {
+        String newPath = pathNotStartingWithSeparator(path, directorySeparator);
+        newPath = pathNotEndingWithSeparator(newPath, directorySeparator);
+        return newPath;
     }
 
     private static String pathNotStartingWithSeparator(final String path, final String separator)
@@ -171,8 +199,20 @@ public class SparkFileHelper implements Serializable
             return EMPTY_STRING;
         }
 
-        final int firstSeparatorIndex = path.indexOf(separator);
-        return firstSeparatorIndex == 0 ? path.substring(1) : path;
+        String scrubbedPath = path;
+        while (scrubbedPath.indexOf(separator) == 0)
+        {
+            final int firstSeparatorIndex = scrubbedPath.indexOf(separator);
+            if (firstSeparatorIndex == 0)
+            {
+                scrubbedPath = scrubbedPath.substring(1);
+            }
+            else
+            {
+                break;
+            }
+        }
+        return scrubbedPath;
     }
 
     private static String pathStartingWithSeparator(final String path, final String separator)

--- a/src/test/java/org/openstreetmap/atlas/generator/PbfLocatorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/PbfLocatorTest.java
@@ -12,14 +12,18 @@ import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.PbfLocator.LocatedPbf;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
+import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceSchemeType;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.MultiPolygon;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author matthieun
@@ -27,14 +31,15 @@ import org.openstreetmap.atlas.utilities.collections.Iterables;
 public class PbfLocatorTest
 {
     private static final String version = "07082015";
+    private static final Logger logger = LoggerFactory.getLogger(PbfLocatorTest.class);
 
     @Before
     public void init()
     {
-        uploadFile(10 + "/" + 291 + "-" + 438 + ".osm.pbf");
-        uploadFile(10 + "/" + 292 + "-" + 438 + ".osm.pbf");
-        uploadFile(10 + "-" + 291 + "-" + 438 + ".pbf");
-        uploadFile(10 + "-" + 292 + "-" + 438 + ".pbf");
+        uploadFile(10 + "/" + 291 + "-" + 438 + FileSuffix.PBF.toString());
+        uploadFile(10 + "/" + 292 + "-" + 438 + FileSuffix.PBF.toString());
+        uploadFile(10 + "-" + 291 + "-" + 438 + FileSuffix.PBF.toString());
+        uploadFile(10 + "-" + 292 + "-" + 438 + FileSuffix.PBF.toString());
         System.out.println(ResourceFileSystem.files());
     }
 
@@ -43,7 +48,8 @@ public class PbfLocatorTest
     {
         // Test a default scheme
         final SlippyTilePersistenceScheme scheme = new SlippyTilePersistenceScheme(
-                PbfLocator.DEFAULT_SCHEME);
+                SlippyTilePersistenceSchemeType.ZZ_XX_YY_PBF);
+        logger.warn("{}", scheme.getScheme());
         final PbfContext pbfContext = new PbfContext("resource://" + version,
                 new SlippyTileSharding(10), scheme);
         final PbfLocator locator = new PbfLocator(pbfContext,
@@ -60,8 +66,8 @@ public class PbfLocatorTest
     {
         // Test a non-default scheme
         final SlippyTilePersistenceScheme scheme = new SlippyTilePersistenceScheme(
-                SlippyTilePersistenceScheme.ZOOM + "/" + SlippyTilePersistenceScheme.X_INDEX + "-"
-                        + SlippyTilePersistenceScheme.Y_INDEX + ".osm.pbf");
+                SlippyTilePersistenceSchemeType.ZZ_SLASH_XX_YY_PBF);
+        logger.warn("{}", scheme.getScheme());
         final PbfContext pbfContext = new PbfContext("resource://" + version,
                 new SlippyTileSharding(10), scheme);
         final PbfLocator locator = new PbfLocator(pbfContext,

--- a/src/test/java/org/openstreetmap/atlas/generator/persistence/scheme/SlippyTilePersistenceSchemeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/persistence/scheme/SlippyTilePersistenceSchemeTest.java
@@ -1,0 +1,70 @@
+package org.openstreetmap.atlas.generator.persistence.scheme;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
+import org.openstreetmap.atlas.geography.sharding.SlippyTile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author lcram
+ */
+public class SlippyTilePersistenceSchemeTest
+{
+    private static final Logger logger = LoggerFactory.getLogger(SlippyTilePersistenceScheme.class);
+
+    @Test(expected = CoreException.class)
+    public void testInvalidSchemeString()
+    {
+        final SlippyTilePersistenceScheme invalidScheme = SlippyTilePersistenceScheme
+                .getSchemeInstanceFromString("zz/xx/");
+    }
+
+    @Test
+    public void testVariousSchemes()
+    {
+        final SlippyTilePersistenceScheme scheme1 = SlippyTilePersistenceScheme
+                .getSchemeInstanceFromString("zz/");
+        final String path1 = SparkFileHelper.combine("resource://parentPath",
+                scheme1.compile("12", "12", "12"), "morePath");
+        Assert.assertEquals("resource://parentPath/12/morePath", path1);
+
+        final SlippyTilePersistenceScheme scheme2 = new SlippyTilePersistenceScheme(
+                SlippyTilePersistenceSchemeType.ZZ_XX_YY_SUBFOLDERS_PBF);
+        final String path2 = SparkFileHelper.combine("resource://parentPath",
+                scheme2.compile(new SlippyTile(12, 12, 12)));
+        Assert.assertEquals("resource://parentPath/12/12/12/12-12-12.pbf", path2);
+
+        final SlippyTilePersistenceScheme scheme3 = new SlippyTilePersistenceScheme(
+                SlippyTilePersistenceSchemeType.ZZ_SLASH_XX_YY_OSMPBF);
+        final String path3 = SparkFileHelper.combine("resource://parentPath",
+                scheme3.compile(new SlippyTile(12, 12, 12)));
+        Assert.assertEquals("resource://parentPath/12/12-12.osm.pbf", path3);
+
+        final SlippyTilePersistenceScheme scheme4 = new SlippyTilePersistenceScheme(
+                SlippyTilePersistenceSchemeType.EMPTY);
+        final String path4 = SparkFileHelper.combine("resource://parentPath",
+                scheme4.compile(new SlippyTile(12, 12, 12)));
+        Assert.assertEquals("resource://parentPath", path4);
+
+        final SlippyTilePersistenceScheme scheme5 = new SlippyTilePersistenceScheme(
+                SlippyTilePersistenceSchemeType.EMPTY);
+        final String path5 = SparkFileHelper.combine("resource://parentPath",
+                scheme5.compile(new SlippyTile(12, 12, 12)), "morePath");
+        Assert.assertEquals("resource://parentPath/morePath", path5);
+
+        final SlippyTilePersistenceScheme scheme6 = SlippyTilePersistenceScheme
+                .getSchemeInstanceFromString("zz-xx-yy.pbf");
+        final String path6 = SparkFileHelper.combine("resource://parentPath",
+                scheme6.compile("12", "12", "12"));
+        Assert.assertEquals("resource://parentPath/12-12-12.pbf", path6);
+
+        final SlippyTilePersistenceScheme scheme7 = SlippyTilePersistenceScheme
+                .getSchemeInstanceFromString("ZZ_XX_YY_PBF");
+        final String path7 = SparkFileHelper.combine("resource://parentPath",
+                scheme7.compile("12", "12", "12"));
+        Assert.assertEquals("resource://parentPath/12-12-12.pbf", path7);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -5,7 +5,8 @@ import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openstreetmap.atlas.generator.AtlasGeneratorParameters;
+import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
+import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceSchemeType;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.Resource;
@@ -23,7 +24,8 @@ public class HadoopAtlasFileCacheTest
         final File parentAtlasCountry = new File(parentAtlas + "/AAA");
         final String fullParentPathURI = "file://" + parentAtlas.toString();
         final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(fullParentPathURI,
-                AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+                new SlippyTilePersistenceScheme(SlippyTilePersistenceSchemeType.ZZ_SUBFOLDER),
+                new HashMap<>());
         parentAtlasCountry.mkdirs();
         try
         {
@@ -61,9 +63,13 @@ public class HadoopAtlasFileCacheTest
         final File parentAtlasCountry = new File(parentAtlas + "/AAA");
         final String fullParentPathURI = "file://" + parentAtlas.toString();
         final HadoopAtlasFileCache cache1 = new HadoopAtlasFileCache(fullParentPathURI,
-                "namespace1", AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+                "namespace1",
+                new SlippyTilePersistenceScheme(SlippyTilePersistenceSchemeType.ZZ_SUBFOLDER),
+                new HashMap<>());
         final HadoopAtlasFileCache cache2 = new HadoopAtlasFileCache(fullParentPathURI,
-                "namespace2", AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+                "namespace2",
+                new SlippyTilePersistenceScheme(SlippyTilePersistenceSchemeType.ZZ_SUBFOLDER),
+                new HashMap<>());
         parentAtlasCountry.mkdirs();
         try
         {
@@ -122,7 +128,8 @@ public class HadoopAtlasFileCacheTest
         final File parentAtlasCountry = new File(parentAtlas + "/AAA");
         final String fullParentPathURI = "file://" + parentAtlas.toString();
         final HadoopAtlasFileCache cache = new HadoopAtlasFileCache(fullParentPathURI,
-                AtlasGeneratorParameters.ATLAS_SCHEME.get("zz/"), new HashMap<>());
+                new SlippyTilePersistenceScheme(SlippyTilePersistenceSchemeType.ZZ_SUBFOLDER),
+                new HashMap<>());
         parentAtlasCountry.mkdirs();
         try
         {

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelperTest.java
@@ -223,6 +223,50 @@ public class SparkFileHelperTest
     }
 
     @Test
+    public void testPathOperations()
+    {
+        final String dir1 = "dir1";
+        final String dir2 = "dir2";
+        final String combined1 = SparkFileHelper.combine(dir1, dir2);
+        Assert.assertEquals("dir1/dir2", combined1);
+        Assert.assertEquals("dir1", SparkFileHelper.parentPath(combined1));
+
+        final String combined2 = SparkFileHelper.combine(dir1, dir2, dir2, dir1);
+        Assert.assertEquals("dir1/dir2/dir2/dir1", combined2);
+        Assert.assertEquals("dir1/dir2/dir2", SparkFileHelper.parentPath(combined2));
+
+        final String dir3 = "dir3/";
+        final String dir4 = "/dir4";
+        final String combined3 = SparkFileHelper.combine(dir3, dir4);
+        Assert.assertEquals("dir3/dir4", combined3);
+        Assert.assertEquals("dir3", SparkFileHelper.parentPath(combined3));
+
+        final String dir5 = "dir5////";
+        final String dir6 = "dir6";
+        final String combined4 = SparkFileHelper.combine(dir5, dir6, dir5, dir6);
+        Assert.assertEquals("dir5/dir6/dir5/dir6", combined4);
+
+        final String combined5 = SparkFileHelper.combine(dir5, dir6, dir5);
+        Assert.assertEquals("dir5/dir6/dir5", combined5);
+
+        final String dir7 = "dir7////";
+        final String dir8 = "//////dir8";
+        final String combined6 = SparkFileHelper.combine(dir7, dir8);
+        Assert.assertEquals("dir7/dir8", combined6);
+
+        final String combined7 = SparkFileHelper.combine(dir1, dir2, dir3, dir4, dir5, dir6, dir7,
+                dir8, dir7, dir6, dir5, dir4, dir3, dir2, dir1);
+        Assert.assertEquals(
+                "dir1/dir2/dir3/dir4/dir5/dir6/dir7/dir8/dir7/dir6/dir5/dir4/dir3/dir2/dir1",
+                combined7);
+
+        final String prefix = "hdfs://somePath/";
+        final String suffix = "/anotherComponent//";
+        Assert.assertEquals("hdfs://somePath/anotherComponent",
+                SparkFileHelper.combine(prefix, suffix));
+    }
+
+    @Test
     public void testRename() throws IOException
     {
         // Create temporary files


### PR DESCRIPTION
### Description:

~DNM: doing some last minute testing. Hold merge until ready.~
Ready for merge.

Refactored the `SlippyTilePersistenceScheme` to disallow unsanitized user schemes. Additionally, all hardcoded path construction code (i.e. `foo + "/" + bar`) has been removed.

### Potential Impact:

Potential downstream impact. `SlippyTilePersistenceScheme` still recognizes parameters in formats like `zz/xx/yy`, but now it will throw errors if the format does not match a predefined scheme in `SlippyTilePersistenceSchemeType`. If downstream code is using an unrecognized scheme string, it will either need to be added as a new type in `SlippyTilePersistenceSchemeType`, or the downstream code must update.

### Unit Test Approach:

New unit tests added (see diff), and old unit/integration tests pass.

### Test Results:

All tests pass. Additionally, I built some atlas files locally and things look OK.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)