### PR TITLE
Dynamic slicing

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.3.5',
+    atlas: '5.4.0',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -232,7 +232,7 @@ public class AtlasGenerator extends SparkJob
         final JavaPairRDD<String, Atlas> fullySlicedRawAtlasShardsRDD = countryRawAtlasRDD
                 .mapToPair(AtlasGeneratorHelper.sliceRawAtlasRelations(broadcastBoundaries,
                         broadcastSharding, lineSlicedSubAtlasPath, lineSlicedAtlasPath, atlasScheme,
-                        sparkContext, broadcastLoadingOptions, tasks))
+                        sparkContext))
                 .filter(tuple -> tuple._2() != null);
 
         // Persist the RDD and save the intermediary state

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -90,11 +90,10 @@ public final class AtlasGeneratorHelper implements Serializable
     static final Predicate<AtlasEntity> pointPredicate = entity -> entity instanceof Point;
 
     // Bring in all lines that will become edges
-    static final Predicate<AtlasEntity> relationPredicate = entity ->
-    {
-        return entity.getType().equals(ItemType.RELATION) && Validators.isOfType(entity,
-                NaturalTag.class, NaturalTag.WATER, NaturalTag.COASTLINE);
-    };
+    static final Predicate<AtlasEntity> relationPredicate = entity -> entity.getType()
+            .equals(ItemType.RELATION)
+            && Validators.isOfType(entity, NaturalTag.class, NaturalTag.WATER,
+                    NaturalTag.COASTLINE);
 
     // Dynamic expansion filter will be a combination of points and lines
     public static final Predicate<AtlasEntity> subAtlasFilter = entity -> pointPredicate
@@ -115,10 +114,7 @@ public final class AtlasGeneratorHelper implements Serializable
             final StringList countriesForShardList = boundaries
                     .countryCodesOverlappingWith(shard.bounds());
             final Set<String> countriesForShard = new HashSet<>();
-            countriesForShardList.forEach(countryCode ->
-            {
-                countriesForShard.add(countryCode);
-            });
+            countriesForShardList.forEach(countriesForShard::add);
 
             final Set<Resource> atlasResources = new HashSet<>();
             // If this is the initial shard, load in all sliced lines not just water relation lines
@@ -506,7 +502,7 @@ public final class AtlasGeneratorHelper implements Serializable
             // Grab the tuple contents
             final String shardName = tuple._1();
             final Atlas rawAtlas = tuple._2();
-            logger.info("Starting slicing raw Atlas {}", rawAtlas.getName());
+            logger.info("Starting line slicing raw Atlas {}", rawAtlas.getName());
             final Time start = Time.now();
 
             try
@@ -528,13 +524,14 @@ public final class AtlasGeneratorHelper implements Serializable
 
             catch (final Throwable e) // NOSONAR
             {
-                throw new CoreException("Slicing raw Atlas failed for {}", shardName, e);
+                throw new CoreException("Line slicing raw Atlas failed for {}", shardName, e);
             }
 
-            logger.info("Finished slicing raw Atlas for {} in {}", shardName, start.elapsedSince());
+            logger.info("Finished line slicing raw Atlas for {} in {}", shardName,
+                    start.elapsedSince());
 
             // Report on memory usage
-            logger.info("Printing memory after loading sliced raw Atlas for {}", shardName);
+            logger.info("Printing memory after loading line sliced raw Atlas for {}", shardName);
             Memory.printCurrentMemory();
 
             // Output the Name/Atlas couple
@@ -545,9 +542,7 @@ public final class AtlasGeneratorHelper implements Serializable
     protected static PairFunction<Tuple2<String, Atlas>, String, Atlas> sliceRawAtlasRelations(
             final Broadcast<CountryBoundaryMap> boundaries, final Broadcast<Sharding> sharding,
             final String lineSlicedSubAtlasPath, final String lineSlicedAtlasPath,
-            final SlippyTilePersistenceScheme atlasScheme, final Map<String, String> sparkContext,
-            final Broadcast<Map<String, String>> loadingOptions,
-            final List<AtlasGenerationTask> tasks)
+            final SlippyTilePersistenceScheme atlasScheme, final Map<String, String> sparkContext)
     {
         return tuple ->
         {
@@ -556,7 +551,7 @@ public final class AtlasGeneratorHelper implements Serializable
             // Grab the tuple contents
             final String shardName = tuple._1();
             final Atlas rawAtlas = tuple._2();
-            logger.info("Starting slicing raw Atlas {}", rawAtlas.getName());
+            logger.info("Starting relation slicing raw Atlas {}", rawAtlas.getName());
             final Time start = Time.now();
 
             try
@@ -585,13 +580,14 @@ public final class AtlasGeneratorHelper implements Serializable
 
             catch (final Throwable e) // NOSONAR
             {
-                throw new CoreException("Slicing raw Atlas failed for {}", shardName, e);
+                throw new CoreException("Relation slicing raw Atlas failed for {}", shardName, e);
             }
 
-            logger.info("Finished slicing raw Atlas for {} in {}", shardName, start.elapsedSince());
+            logger.info("Finished relation slicing raw Atlas for {} in {}", shardName,
+                    start.elapsedSince());
 
             // Report on memory usage
-            logger.info("Printing memory after loading sliced raw Atlas for {}", shardName);
+            logger.info("Printing memory after loading fully sliced Atlas for {}", shardName);
             Memory.printCurrentMemory();
 
             // Output the Name/Atlas couple

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -3,11 +3,13 @@ package org.openstreetmap.atlas.generator;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
@@ -20,16 +22,23 @@ import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.items.Point;
+import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.raw.sectioning.WaySectionProcessor;
 import org.openstreetmap.atlas.geography.atlas.raw.slicing.RawAtlasCountrySlicer;
 import org.openstreetmap.atlas.geography.atlas.statistics.AtlasStatistics;
 import org.openstreetmap.atlas.geography.atlas.statistics.Counter;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.geography.sharding.CountryShard;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.tags.NaturalTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.runtime.system.memory.Memory;
 import org.openstreetmap.atlas.utilities.time.Time;
@@ -74,8 +83,82 @@ public final class AtlasGeneratorHelper implements Serializable
 
     private static final long serialVersionUID = 1300098384789754747L;
     private static final Logger logger = LoggerFactory.getLogger(AtlasGeneratorHelper.class);
+    private static final String LINE_SLICED_SUBATLAS_NAMESPACE = "lineSlicedSubAtlas";
+    private static final String LINE_SLICED_ATLAS_NAMESPACE = "lineSlicedAtlas";
 
     private static final AtlasResourceLoader ATLAS_LOADER = new AtlasResourceLoader();
+
+    @SuppressWarnings("unchecked")
+    protected static Function<Shard, Optional<Atlas>> atlasFetcher(
+            final HadoopAtlasFileCache lineSlicedSubAtlasCache,
+            final HadoopAtlasFileCache lineSlicedAtlasCache, final CountryBoundaryMap boundaries,
+            final String countryBeingSliced, final Shard initialShard)
+    {
+        // & Serializable is very important as that function will be passed around by Spark, and
+        // functions are not serializable by default.
+        return (Function<Shard, Optional<Atlas>> & Serializable) shard ->
+        {
+            final StringList countriesForShardList = boundaries
+                    .countryCodesOverlappingWith(shard.bounds());
+            final Set<String> countriesForShard = new HashSet<>();
+            countriesForShardList.forEach(countryCode ->
+            {
+                countriesForShard.add(countryCode);
+            });
+
+            final Set<Resource> atlasResources = new HashSet<>();
+            // If this is the initial shard, load in all sliced lines not just water relation lines
+            if (shard.equals(initialShard))
+            {
+                final Optional<Resource> cachedInitialShardResource = lineSlicedAtlasCache
+                        .get(countryBeingSliced, shard);
+                if (cachedInitialShardResource.isPresent())
+                {
+                    atlasResources.add(cachedInitialShardResource.get());
+                    // MultiAtlas the water relation subatlases for other countries on this shard
+                    countriesForShard.forEach(country ->
+                    {
+                        if (!country.equals(countryBeingSliced))
+                        {
+                            final Optional<Resource> cachedAtlas = lineSlicedSubAtlasCache
+                                    .get(country, shard);
+                            if (cachedAtlas.isPresent())
+                            {
+                                logger.debug(
+                                        "Cache hit, loading sliced subAtlas for Shard {} and country {}",
+                                        shard, country);
+                                atlasResources.add(cachedAtlas.get());
+                            }
+                        }
+                    });
+                    return Optional.ofNullable(MultiAtlas.loadFromPackedAtlas(atlasResources));
+                }
+                else
+                {
+                    logger.error("No Atlas file found for initial Shard {}!", shard);
+                    return Optional.empty();
+                }
+            }
+            else
+            {
+                // If the shard is in the country being sliced, multi-atlas all sliced water
+                // relation data together and return that
+                countriesForShard.forEach(country ->
+                {
+                    final Optional<Resource> cachedAtlas = lineSlicedSubAtlasCache.get(country,
+                            shard);
+                    if (cachedAtlas.isPresent())
+                    {
+                        logger.debug(
+                                "Cache hit, loading sliced subAtlas for Shard {} and country {}",
+                                shard, country);
+                        atlasResources.add(cachedAtlas.get());
+                    }
+                });
+                return Optional.ofNullable(MultiAtlas.loadFromPackedAtlas(atlasResources));
+            }
+        };
+    }
 
     /**
      * @param atlasCache
@@ -86,6 +169,7 @@ public final class AtlasGeneratorHelper implements Serializable
      *            All available shards for given country, to avoid fetching shards that do not exist
      * @return A function that returns an {@link Atlas} given a {@link Shard}
      */
+    @SuppressWarnings("unchecked")
     protected static Function<Shard, Optional<Atlas>> atlasFetcher(
             final HadoopAtlasFileCache atlasCache, final String country,
             final Set<Shard> validShards)
@@ -389,6 +473,174 @@ public final class AtlasGeneratorHelper implements Serializable
 
             // Output the Name/Atlas couple
             return new Tuple2<>(tuple._1(), slicedAtlas);
+        };
+    }
+
+    /**
+     * @param boundaries
+     *            The {@link CountryBoundaryMap} to use for slicing
+     * @return a Spark {@link PairFunction} that processes a tuple of shard-name and raw atlas,
+     *         slices the raw atlas and returns the sliced raw atlas for that shard name.
+     */
+    protected static PairFunction<Tuple2<String, Atlas>, String, Atlas> sliceRawAtlasLines(
+            final Broadcast<CountryBoundaryMap> boundaries)
+    {
+        return tuple ->
+        {
+            final Atlas slicedAtlas;
+
+            // Grab the tuple contents
+            final String shardName = tuple._1();
+            final Atlas rawAtlas = tuple._2();
+            logger.info("Starting slicing raw Atlas {}", rawAtlas.getName());
+            final Time start = Time.now();
+
+            try
+            {
+                // Extract the country code
+                final String countryName = shardName.split(CountryShard.COUNTRY_SHARD_SEPARATOR)[0];
+                if (countryName != null)
+                {
+                    // Slice the Atlas
+                    slicedAtlas = new RawAtlasCountrySlicer(countryName, boundaries.getValue())
+                            .sliceLines(rawAtlas);
+                }
+                else
+                {
+                    slicedAtlas = null;
+                    logger.error("Unable to extract valid country code for {}", shardName);
+                }
+            }
+
+            catch (final Throwable e) // NOSONAR
+            {
+                throw new CoreException("Slicing raw Atlas failed for {}", shardName, e);
+            }
+
+            logger.info("Finished slicing raw Atlas for {} in {}", shardName, start.elapsedSince());
+
+            // Report on memory usage
+            logger.info("Printing memory after loading sliced raw Atlas for {}", shardName);
+            Memory.printCurrentMemory();
+
+            // Output the Name/Atlas couple
+            return new Tuple2<>(tuple._1(), slicedAtlas);
+        };
+    }
+
+    protected static PairFunction<Tuple2<String, Atlas>, String, Atlas> sliceRawAtlasRelations(
+            final Broadcast<CountryBoundaryMap> boundaries, final Broadcast<Sharding> sharding,
+            final String lineSlicedSubAtlasPath, final String lineSlicedAtlasPath,
+            final SlippyTilePersistenceScheme atlasScheme, final Map<String, String> sparkContext,
+            final Broadcast<Map<String, String>> loadingOptions,
+            final List<AtlasGenerationTask> tasks)
+    {
+        return tuple ->
+        {
+            final Atlas slicedAtlas;
+
+            // Grab the tuple contents
+            final String shardName = tuple._1();
+            final Atlas rawAtlas = tuple._2();
+            logger.info("Starting slicing raw Atlas {}", rawAtlas.getName());
+            final Time start = Time.now();
+
+            try
+            {
+                // Calculate the shard, country name and possible shards
+                final String countryShardString = tuple._1();
+                final CountryShard countryShard = CountryShard.forName(countryShardString);
+                final String country = countryShard.getCountry();
+
+                final HadoopAtlasFileCache lineSlicedSubAtlasCache = new HadoopAtlasFileCache(
+                        lineSlicedSubAtlasPath, LINE_SLICED_SUBATLAS_NAMESPACE, atlasScheme,
+                        sparkContext);
+
+                final HadoopAtlasFileCache lineSlicedAtlasCache = new HadoopAtlasFileCache(
+                        lineSlicedAtlasPath, LINE_SLICED_ATLAS_NAMESPACE, atlasScheme,
+                        sparkContext);
+
+                final Function<Shard, Optional<Atlas>> atlasFetcher = AtlasGeneratorHelper
+                        .atlasFetcher(lineSlicedSubAtlasCache, lineSlicedAtlasCache,
+                                boundaries.getValue(), country, countryShard.getShard());
+
+                // Slice the Atlas
+                slicedAtlas = new RawAtlasCountrySlicer(country, boundaries.getValue(),
+                        sharding.getValue(), atlasFetcher).sliceRelations(countryShard.getShard());
+            }
+
+            catch (final Throwable e) // NOSONAR
+            {
+                throw new CoreException("Slicing raw Atlas failed for {}", shardName, e);
+            }
+
+            logger.info("Finished slicing raw Atlas for {} in {}", shardName, start.elapsedSince());
+
+            // Report on memory usage
+            logger.info("Printing memory after loading sliced raw Atlas for {}", shardName);
+            Memory.printCurrentMemory();
+
+            // Output the Name/Atlas couple
+            return new Tuple2<>(tuple._1(), slicedAtlas);
+        };
+    }
+
+    protected static PairFunction<Tuple2<String, Atlas>, String, Atlas> subatlasWaterRelations()
+    {
+        return tuple ->
+        {
+            final Atlas subAtlas;
+
+            // Grab the tuple contents
+            final String shardName = tuple._1();
+            final Atlas subAtlasFromRawShardAtlas = tuple._2();
+            logger.info("Starting sub Atlas for water relations of raw sub Atlas {}",
+                    subAtlasFromRawShardAtlas.getName());
+            final Time start = Time.now();
+
+            try
+            {
+                // Bring in all points that are part of any line that will become an edge
+                final Predicate<AtlasEntity> pointPredicate = entity -> entity instanceof Point;
+
+                // Bring in all lines that will become edges
+                final Predicate<AtlasEntity> relationPredicate = entity ->
+                {
+                    return entity.getType().equals(ItemType.RELATION) && Validators.isOfType(entity,
+                            NaturalTag.class, NaturalTag.WATER, NaturalTag.COASTLINE);
+                };
+
+                // Dynamic expansion filter will be a combination of points and lines
+                final Predicate<AtlasEntity> dynamicAtlasExpansionFilter = entity -> pointPredicate
+                        .test(entity) || relationPredicate.test(entity);
+                // Slice the Atlas
+                final Optional<Atlas> subAtlasOptional = subAtlasFromRawShardAtlas
+                        .subAtlas(dynamicAtlasExpansionFilter, AtlasCutType.SOFT_CUT);
+                if (subAtlasOptional.isPresent())
+                {
+                    subAtlas = subAtlasOptional.get();
+                }
+                else
+                {
+                    subAtlas = null;
+                    logger.error("Unable to extract valid subAtlas code for {}", shardName);
+                }
+
+            }
+
+            catch (final Throwable e) // NOSONAR
+            {
+                throw new CoreException("Water relations sub Atlas failed for {}", shardName, e);
+            }
+
+            logger.info("Finished sub Atlas for {} in {}", shardName, start.elapsedSince());
+
+            // Report on memory usage
+            logger.info("Printing memory after loading sub Atlas for {}", shardName);
+            Memory.printCurrentMemory();
+
+            // Output the Name/Atlas couple
+            return new Tuple2<>(tuple._1(), subAtlas);
         };
     }
 

--- a/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
@@ -53,11 +53,11 @@ public class RawAtlasCreator extends Command
      */
     private enum RawAtlasFlavor
     {
-        RawAtlas("raw"),
-        LineSlicedAtlas("lineSliced"),
-        RelationSlicedAtlas("relationSliced"),
-        SlicedAtlas("sliced"),
-        SectionedAtlas("sectioned");
+        RAW_ATLAS("raw"),
+        LINE_SLICED_ATLAS("lineSliced"),
+        RELATION_SLICED_ATLAS("relationSliced"),
+        SLICED_ATLAS("sliced"),
+        SECTIONED_ATLAS("sectioned");
 
         private final String flavorString;
 
@@ -91,6 +91,7 @@ public class RawAtlasCreator extends Command
     private static final String DEFAULT_FULLY_SLICED_ATLAS_CACHE_NAME = "__RawAtlasCreator_fullySlicedAtlasCache__";
     private static final String DEFAULT_WATER_RELATION_SUB_ATLAS_CACHE_PATH = "__RawAtlasCreator_waterRelationSubAtlasCache__";
 
+    private static final String USER_HOME = System.getProperty("user.home");
     /*
      * A path to a country boundary map file
      */
@@ -130,13 +131,13 @@ public class RawAtlasCreator extends Command
     public static final Switch<String> LINE_SLICED_ATLAS_CACHE_PATH = new Switch<>(
             "lineSlicedAtlasCache", "The path to the line sliced atlas cache for DynamicAtlas",
             StringConverter.IDENTITY, Optionality.OPTIONAL,
-            System.getProperty("user.home") + "/" + DEFAULT_LINE_SLICED_ATLAS_CACHE_NAME);
+            SparkFileHelper.combine(USER_HOME, DEFAULT_LINE_SLICED_ATLAS_CACHE_NAME));
 
     public static final Switch<String> WATER_RELATION_SUB_ATLAS_CACHE_PATH = new Switch<>(
             "waterRelationSubAtlasCache",
             "The path to the line-sliced water relation subatlas cache for DynamicAtlas",
             StringConverter.IDENTITY, Optionality.OPTIONAL,
-            System.getProperty("user.home") + "/" + DEFAULT_WATER_RELATION_SUB_ATLAS_CACHE_PATH);
+            SparkFileHelper.combine(USER_HOME, DEFAULT_WATER_RELATION_SUB_ATLAS_CACHE_PATH));
 
     /*
      * The path to the cache of fully sliced atlases. This class uses DynamicAtlas to do way
@@ -146,12 +147,11 @@ public class RawAtlasCreator extends Command
     public static final Switch<String> FULLY_SLICED_ATLAS_CACHE_PATH = new Switch<>(
             "fullySlicedAtlasCache", "The path to the fully sliced atlas cache for DynamicAtlas",
             StringConverter.IDENTITY, Optionality.OPTIONAL,
-            System.getProperty("user.home") + "/" + DEFAULT_FULLY_SLICED_ATLAS_CACHE_NAME);
+            SparkFileHelper.combine(USER_HOME, DEFAULT_FULLY_SLICED_ATLAS_CACHE_NAME));
 
     public static final Switch<String> RAW_ATLAS_CACHE_PATH = new Switch<>("rawAtlasCache",
             "The path to the sliced atlas cache for DynamicAtlas", StringConverter.IDENTITY,
-            Optionality.OPTIONAL,
-            SparkFileHelper.combine(System.getProperty("user.home"), DEFAULT_RAW_ATLAS_CACHE_NAME));
+            Optionality.OPTIONAL, SparkFileHelper.combine(USER_HOME, DEFAULT_RAW_ATLAS_CACHE_NAME));
 
     /*
      * If we attempt to populate the sliced atlas cache and still miss, we can optionally fail fast.
@@ -199,11 +199,11 @@ public class RawAtlasCreator extends Command
      * The flavor of raw atlas you would like as output (ie. raw, sliced, sectioned)
      */
     public static final Switch<RawAtlasFlavor> ATLAS_FLAVOR = new Switch<>("rawAtlasFlavor",
-            "Which flavor of raw atlas - " + RawAtlasFlavor.RawAtlas.toString() + ", "
-                    + RawAtlasFlavor.SlicedAtlas.toString() + ", or "
-                    + RawAtlasFlavor.SectionedAtlas.toString(),
+            "Which flavor of raw atlas - " + RawAtlasFlavor.RAW_ATLAS.toString() + ", "
+                    + RawAtlasFlavor.SLICED_ATLAS.toString() + ", or "
+                    + RawAtlasFlavor.SECTIONED_ATLAS.toString(),
             RawAtlasFlavor::flavorStringToRawAtlasFlavor, Optionality.OPTIONAL,
-            RawAtlasFlavor.SectionedAtlas.toString());
+            RawAtlasFlavor.SECTIONED_ATLAS.toString());
 
     /*
      * Change the serialization to legacy Java format if desired.
@@ -245,9 +245,8 @@ public class RawAtlasCreator extends Command
         PbfLoader.setAtlasSaveFolder(output);
         final PackedAtlas atlas = runGenerationForFlavor(atlasFlavor, countryBoundaryMap,
                 shardToBuild, pbfPath, rawAtlasCachePath, lineSlicedAtlasCachePath,
-                waterRelationSubAtlasCachePath, fullySlicedAtlasCachePath,
-                failFastOnSlicedCacheMiss, failFastOnSlicedCacheMiss, pbfScheme, pbfSharding,
-                sharding, countryName);
+                fullySlicedAtlasCachePath, failFastOnSlicedCacheMiss, failFastOnSlicedCacheMiss,
+                pbfScheme, pbfSharding, sharding, countryName);
 
         if (useJavaFormat)
         {
@@ -325,17 +324,14 @@ public class RawAtlasCreator extends Command
             final CountryBoundaryMap countryBoundaryMap, final Sharding sharding,
             final Function<Shard, Optional<Atlas>> lineSlicedAtlasFetcher)
     {
-        final Atlas fullySlicedAtlas = new RawAtlasCountrySlicer(countryName, countryBoundaryMap,
-                sharding, lineSlicedAtlasFetcher).sliceRelations(shardToBuild);
-        return fullySlicedAtlas;
+        return new RawAtlasCountrySlicer(countryName, countryBoundaryMap, sharding,
+                lineSlicedAtlasFetcher).sliceRelations(shardToBuild);
     }
 
     private Atlas generateLineSlicedAtlas(final String countryName,
             final CountryBoundaryMap countryBoundaryMap, final Atlas rawAtlas)
     {
-        final Atlas slicedLinesRawAtlas = new RawAtlasCountrySlicer(countryName, countryBoundaryMap)
-                .sliceLines(rawAtlas);
-        return slicedLinesRawAtlas;
+        return new RawAtlasCountrySlicer(countryName, countryBoundaryMap).sliceLines(rawAtlas);
     }
 
     private Atlas generateRawAtlas(final String pbfPath, final Shard shardToBuild)
@@ -348,7 +344,7 @@ public class RawAtlasCreator extends Command
         return rawAtlasGenerator.build();
     }
 
-    private Atlas generateSectionedAtlas(final String countryName, final Shard shardToBuild,
+    private Atlas generateSectionedAtlas(final Shard shardToBuild,
             final CountryBoundaryMap countryBoundaryMap, final Sharding sharding,
             final Function<Shard, Optional<Atlas>> fullySlicedAtlasFetcher)
     {
@@ -427,15 +423,14 @@ public class RawAtlasCreator extends Command
     private PackedAtlas runGenerationForFlavor(final RawAtlasFlavor atlasFlavor,
             final CountryBoundaryMap countryBoundaryMap, final Shard shardToBuild,
             final String pbfPath, final String rawAtlasCachePath, final String lineSlicedCachePath,
-            final String waterRelationSubAtlasCachePath, final String fullySlicedCachePath,
-            final boolean failFastOnRawAtlasCacheMiss, final boolean failFastOnSlicedCacheMiss,
-            final SlippyTilePersistenceScheme pbfScheme, final Sharding pbfSharding,
-            final Sharding sharding, final String countryName)
+            final String fullySlicedCachePath, final boolean failFastOnRawAtlasCacheMiss,
+            final boolean failFastOnSlicedCacheMiss, final SlippyTilePersistenceScheme pbfScheme,
+            final Sharding pbfSharding, final Sharding sharding, final String countryName)
     {
         logger.info("Using raw atlas flavor {}", atlasFlavor);
         final String filename = countryName + CountryShard.COUNTRY_SHARD_SEPARATOR
                 + shardToBuild.getName() + FileSuffix.ATLAS;
-        if (atlasFlavor == RawAtlasFlavor.RawAtlas)
+        if (atlasFlavor == RawAtlasFlavor.RAW_ATLAS)
         {
             final Atlas rawAtlas = generateRawAtlas(pbfPath, shardToBuild);
             saveAtlas(rawAtlasCachePath, filename, (PackedAtlas) rawAtlas);
@@ -450,7 +445,7 @@ public class RawAtlasCreator extends Command
 
         final Atlas fullySlicedAtlas = generateFullySlicedAtlas(countryName, shardToBuild,
                 countryBoundaryMap, sharding, lineSlicedAtlasFetcher);
-        if (atlasFlavor == RawAtlasFlavor.SlicedAtlas)
+        if (atlasFlavor == RawAtlasFlavor.SLICED_ATLAS)
         {
             saveAtlas(fullySlicedCachePath, filename, (PackedAtlas) fullySlicedAtlas);
             return (PackedAtlas) fullySlicedAtlas;
@@ -460,9 +455,9 @@ public class RawAtlasCreator extends Command
                 countryName, countryBoundaryMap, fullySlicedCachePath, sharding,
                 lineSlicedAtlasFetcher);
 
-        final Atlas sectionedAtlas = generateSectionedAtlas(countryName, shardToBuild,
-                countryBoundaryMap, sharding, fullySlicedAtlasFetcher);
-        if (atlasFlavor == RawAtlasFlavor.SectionedAtlas)
+        final Atlas sectionedAtlas = generateSectionedAtlas(shardToBuild, countryBoundaryMap,
+                sharding, fullySlicedAtlasFetcher);
+        if (atlasFlavor == RawAtlasFlavor.SECTIONED_ATLAS)
         {
             return (PackedAtlas) sectionedAtlas;
         }

--- a/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
@@ -225,8 +225,6 @@ public class RawAtlasCreator extends Command
         final String pbfPath = (String) command.get(PBF_PATH);
         final String rawAtlasCachePath = (String) command.get(RAW_ATLAS_CACHE_PATH);
         final String lineSlicedAtlasCachePath = (String) command.get(LINE_SLICED_ATLAS_CACHE_PATH);
-        final String waterRelationSubAtlasCachePath = (String) command
-                .get(WATER_RELATION_SUB_ATLAS_CACHE_PATH);
         final String fullySlicedAtlasCachePath = (String) command
                 .get(FULLY_SLICED_ATLAS_CACHE_PATH);
         final boolean failFastOnSlicedCacheMiss = (boolean) command.get(FAIL_FAST_CACHE_MISS);

--- a/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
@@ -273,7 +273,6 @@ public class RawAtlasCreator extends Command
                 FAIL_FAST_CACHE_MISS, PBF_SHARDING, COUNTRY, OUTPUT, ATLAS_FLAVOR, USE_JAVA_ATLAS);
     }
 
-
     private Optional<Atlas> fetchCachedAtlas(final Shard shard, final String countryName,
             final String cachePath)
     {


### PR DESCRIPTION
### Description:

This PR adds compatibility for the new slicing logic in osmlab/atlas#341. Primarily, the changes rework AtlasGenerator and AtlasGeneratorHelper to separate point-and-line slicing from relation slicing, and add in a DynamicAtlas fetcher that will fetch the line sliced Atlases during relation slicing.

Additional work has been done to update RawAtlasCreator to enable these new slicing changes as well.

### Potential Impact:

Output Atlas files should simply incorporate the changes from the new slicing logic, but it is worth pointing out that several subdirectories have been added or renamed as part of the rework. 

### Unit Test Approach:
None

### Test Results:
------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
