### PR TITLE
Save Atlas as line delimited geojson

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -7,7 +7,11 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
+import org.openstreetmap.atlas.streaming.compression.Decompressor;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 
 /**
@@ -23,6 +27,8 @@ public class AtlasGeneratorIntegrationTest
     public static final String PBF_234 = PBF + "/9/9-168-234.osm.pbf";
     public static final String OUTPUT = "resource://test/output";
     public static final String ATLAS_OUTPUT = "resource://test/atlas/DMA";
+    public static final String LINE_DELIMITED_GEOJSON_OUTPUT = "resource://test/"
+            + AtlasGenerator.LINE_DELIMITED_GEOJSON_STATISTICS_FOLDER + "/DMA";
 
     static
     {
@@ -53,6 +59,7 @@ public class AtlasGeneratorIntegrationTest
         arguments.add("-pbfScheme=zz/zz-xx-yy.osm.pbf");
         arguments.add("-atlasScheme=zz/");
         arguments.add("-sharding=dynamic@" + TREE_13);
+        arguments.add("-lineDelimitedGeojsonOutput=true");
         arguments.add(
                 "-sparkOptions=fs.resource.impl=" + ResourceFileSystem.class.getCanonicalName());
 
@@ -72,10 +79,44 @@ public class AtlasGeneratorIntegrationTest
                     resourceFileSystem.exists(new Path(ATLAS_OUTPUT + "/9/DMA_9-168-233.atlas")));
             Assert.assertTrue(
                     resourceFileSystem.exists(new Path(ATLAS_OUTPUT + "/9/DMA_9-168-234.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(
+                    new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-233.ldgeojson.gz")));
+            Assert.assertTrue(resourceFileSystem.exists(
+                    new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-234.ldgeojson.gz")));
+
+            Assert.assertEquals(402,
+                    Iterables.size(resourceForName(resourceFileSystem,
+                            LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-234.ldgeojson.gz")
+                                    .lines()));
+            Assert.assertEquals(402,
+                    Iterables.size(resourceForName(resourceFileSystem,
+                            LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-233.ldgeojson.gz")
+                                    .lines()));
         }
         catch (IllegalArgumentException | IOException e)
         {
             throw new CoreException("Unable to find output Atlas files.", e);
         }
+    }
+
+    private Resource resourceForName(final ResourceFileSystem resourceFileSystem, final String name)
+    {
+        Decompressor decompressor = Decompressor.NONE;
+        if (name.endsWith(FileSuffix.GZIP.toString()))
+        {
+            decompressor = Decompressor.GZIP;
+        }
+        return new InputStreamResource(() ->
+        {
+            try
+            {
+                return resourceFileSystem.open(
+                        new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-234.ldgeojson.gz"));
+            }
+            catch (final Exception e)
+            {
+                throw new CoreException("Unable to open Resource in ResourceFileSystem");
+            }
+        }).withDecompressor(decompressor);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -16,6 +16,7 @@ import org.openstreetmap.atlas.generator.persistence.MultipleAtlasCountryStatist
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasProtoOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasStatisticsOutputFormat;
+import org.openstreetmap.atlas.generator.persistence.MultipleLineDelimitedGeojsonOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.delta.RemovedMultipleAtlasDeltaOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
@@ -60,6 +61,7 @@ public class AtlasGenerator extends SparkJob
     public static final String SHARD_DELTAS_ADDED_FOLDER = "deltasAdded";
     public static final String SHARD_DELTAS_CHANGED_FOLDER = "deltasChanged";
     public static final String SHARD_DELTAS_REMOVED_FOLDER = "deltasRemoved";
+    public static final String LINE_DELIMITED_GEOJSON_STATISTICS_FOLDER = "ldgeojson";
 
     public static void main(final String[] args)
     {
@@ -125,7 +127,8 @@ public class AtlasGenerator extends SparkJob
         final String shardingName = (String) command.get(AtlasGeneratorParameters.SHARDING_TYPE);
         final Sharding sharding = AtlasSharding.forString(shardingName, configuration());
         final Sharding pbfSharding = pbfShardingName != null
-                ? AtlasSharding.forString(pbfShardingName, configuration()) : sharding;
+                ? AtlasSharding.forString(pbfShardingName, configuration())
+                : sharding;
         final PbfContext pbfContext = new PbfContext(pbfPath, pbfSharding, pbfScheme);
         final String shouldAlwaysSliceConfiguration = (String) command
                 .get(AtlasGeneratorParameters.SHOULD_ALWAYS_SLICE_CONFIGURATION);
@@ -142,6 +145,8 @@ public class AtlasGenerator extends SparkJob
         final String output = output(command);
         final boolean useJavaFormat = (boolean) command
                 .get(AtlasGeneratorParameters.USE_JAVA_FORMAT);
+        final boolean lineDelimitedGeojsonOutput = (boolean) command
+                .get(AtlasGeneratorParameters.LINE_DELIMITED_GEOJSON_OUTPUT);
 
         // This has to be converted here, as we need the Spark Context
         final Resource countryBoundaries = resource(countryShapes);
@@ -232,6 +237,15 @@ public class AtlasGenerator extends SparkJob
                     MultipleAtlasProtoOutputFormat.class, new JobConf(configuration()));
         }
         logger.info("\n\n********** SAVED THE FINAL ATLAS **********\n");
+
+        if (lineDelimitedGeojsonOutput)
+        {
+            countryAtlasShardsRDD.saveAsHadoopFile(
+                    getAlternateSubFolderOutput(output, LINE_DELIMITED_GEOJSON_STATISTICS_FOLDER),
+                    Text.class, String.class, MultipleLineDelimitedGeojsonOutputFormat.class,
+                    new JobConf(configuration()));
+            logger.info("\n\n********** SAVED THE LINE DELIMITED GEOJSON ATLAS **********\n");
+        }
 
         // Remove the sliced atlas RDD from cache since we've cached the final RDD
         countrySlicedRawAtlasShardsRDD.unpersist();

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -127,8 +127,7 @@ public class AtlasGenerator extends SparkJob
         final String shardingName = (String) command.get(AtlasGeneratorParameters.SHARDING_TYPE);
         final Sharding sharding = AtlasSharding.forString(shardingName, configuration());
         final Sharding pbfSharding = pbfShardingName != null
-                ? AtlasSharding.forString(pbfShardingName, configuration())
-                : sharding;
+                ? AtlasSharding.forString(pbfShardingName, configuration()) : sharding;
         final PbfContext pbfContext = new PbfContext(pbfPath, pbfSharding, pbfScheme);
         final String shouldAlwaysSliceConfiguration = (String) command
                 .get(AtlasGeneratorParameters.SHOULD_ALWAYS_SLICE_CONFIGURATION);

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -85,6 +85,10 @@ public final class AtlasGeneratorParameters
     public static final Switch<Boolean> USE_JAVA_FORMAT = new Switch<>("useJavaFormat",
             "Generate the atlas files using the java serialization atlas format (as opposed to the protobuf format).",
             Boolean::parseBoolean, Optionality.OPTIONAL, "false");
+    public static final Switch<Boolean> LINE_DELIMITED_GEOJSON_OUTPUT = new Switch<>(
+            "lineDelimitedGeojsonOutput",
+            "Output each shard as a line delimited geojson outout file in the ldgeojson folder.",
+            Boolean::parseBoolean, Optionality.OPTIONAL, "false");
 
     public static StandardConfiguration getStandardConfigurationFrom(
             final Resource configurationResource)
@@ -159,7 +163,8 @@ public final class AtlasGeneratorParameters
         final String waySectioningConfiguration = (String) command
                 .get(WAY_SECTIONING_CONFIGURATION);
         propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null
-                ? null : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
+                ? null
+                : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
 
         final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
         propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
@@ -170,8 +175,9 @@ public final class AtlasGeneratorParameters
                 : FileSystemHelper.resource(pbfWayConfiguration, sparkContext).all());
 
         final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
-        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null
-                ? null : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
+        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
+                pbfRelationConfiguration == null ? null
+                        : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
 
         return propertyMap;
     }
@@ -182,7 +188,7 @@ public final class AtlasGeneratorParameters
                 PBF_SHARDING, PREVIOUS_OUTPUT_FOR_DELTA, CODE_VERSION, DATA_VERSION,
                 EDGE_CONFIGURATION, WAY_SECTIONING_CONFIGURATION, PBF_NODE_CONFIGURATION,
                 PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, ATLAS_SCHEME,
-                SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT);
+                SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT, LINE_DELIMITED_GEOJSON_OUTPUT);
     }
 
     private AtlasGeneratorParameters()

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -163,8 +163,7 @@ public final class AtlasGeneratorParameters
         final String waySectioningConfiguration = (String) command
                 .get(WAY_SECTIONING_CONFIGURATION);
         propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null
-                ? null
-                : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
+                ? null : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
 
         final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
         propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
@@ -175,9 +174,8 @@ public final class AtlasGeneratorParameters
                 : FileSystemHelper.resource(pbfWayConfiguration, sparkContext).all());
 
         final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
-        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
-                pbfRelationConfiguration == null ? null
-                        : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
+        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null
+                ? null : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
 
         return propertyMap;
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/AbstractMultipleAtlasBasedOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/AbstractMultipleAtlasBasedOutputFormat.java
@@ -14,18 +14,17 @@ import org.openstreetmap.atlas.utilities.collections.StringList;
  * {@link AtlasGenerator} follow the same output format structure.
  *
  * @author matthieun
- * @param <Type>
+ * @param <T>
  *            The type to be saved
  */
-public abstract class AbstractMultipleAtlasBasedOutputFormat<Type>
-        extends MultipleOutputFormat<String, Type>
+public abstract class AbstractMultipleAtlasBasedOutputFormat<T>
+        extends MultipleOutputFormat<String, T>
 {
     // By default, save all the shards under each country folder
     public static final String DEFAULT_SCHEME = "";
 
     @Override
-    protected String generateFileNameForKeyValue(final String key, final Type value,
-            final String name)
+    protected String generateFileNameForKeyValue(final String key, final T value, final String name)
     {
         final StringList countrySplit = StringList.split(key, CountryShard.COUNTRY_SHARD_SEPARATOR);
         final String country = countrySplit.get(0);

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/LineDelimitedGeojsonOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/LineDelimitedGeojsonOutputFormat.java
@@ -1,0 +1,33 @@
+package org.openstreetmap.atlas.generator.persistence;
+
+import org.apache.hadoop.mapred.FileOutputFormat;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.streaming.resource.AbstractWritableResource;
+
+/**
+ * {@link FileOutputFormat} that writes an {@link Atlas} as line delimited GeoJson.
+ *
+ * @author matthieun
+ */
+public class LineDelimitedGeojsonOutputFormat extends AbstractFileOutputFormat<Atlas>
+{
+    @Override
+    protected String fileExtension()
+    {
+        return ".ldgeojson";
+    }
+
+    @Override
+    protected boolean isCompressed()
+    {
+        return true;
+    }
+
+    @Override
+    protected void save(final Atlas value, final AbstractWritableResource out)
+    {
+        value.saveAsLineDelimitedGeoJsonFeatures(out, (atlasEntity, jsonMutator) ->
+        {
+        });
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleLineDelimitedGeojsonOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleLineDelimitedGeojsonOutputFormat.java
@@ -1,0 +1,34 @@
+package org.openstreetmap.atlas.generator.persistence;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.mapred.lib.MultipleOutputFormat;
+import org.apache.hadoop.mapred.lib.MultipleTextOutputFormat;
+import org.apache.hadoop.util.Progressable;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+
+/**
+ * {@link MultipleOutputFormat} for the shard {@link Atlas} to line delimited geojson, based on the
+ * model of {@link MultipleTextOutputFormat}
+ *
+ * @author matthieun
+ */
+public class MultipleLineDelimitedGeojsonOutputFormat
+        extends AbstractMultipleAtlasBasedOutputFormat<Atlas>
+{
+    private LineDelimitedGeojsonOutputFormat format = null;
+
+    @Override
+    protected RecordWriter<String, Atlas> getBaseRecordWriter(final FileSystem fileSystem,
+            final JobConf job, final String name, final Progressable progress) throws IOException
+    {
+        if (this.format == null)
+        {
+            this.format = new LineDelimitedGeojsonOutputFormat();
+        }
+        return this.format.getRecordWriter(fileSystem, job, name, progress);
+    }
+}


### PR DESCRIPTION
### Description:

Add an option to save Atlas shards as line delimited geojson files.

### Potential Impact:

No impact, just new option available.

### Unit Test Approach:

Ran job in integration test

### Test Results:

Integration test passes.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
