### PR TITLE
Upgrade to Gradle 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/osmlab/atlas-generator.svg?branch=master)](https://travis-ci.org/osmlab/atlas-generator)
 [![quality gate](https://sonarcloud.io/api/project_badges/measure?project=org.openstreetmap.atlas%3Aatlas-generator&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.openstreetmap.atlas%3Aatlas-generator)
+[![Maven Central](https://img.shields.io/maven-central/v/org.openstreetmap.atlas/atlas-generator.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.openstreetmap.atlas%22%20AND%20a:%22atlas-generator%22)
 
 AtlasGenerator is a Spark Job that generates [Atlas](https://github.com/osmlab/atlas) shards from OSM pbf shards (built from an OSM database with osmosis).
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 	id 'signing'
 	id 'checkstyle'
 	id 'jacoco'
-	id "com.diffplug.gradle.spotless" version "3.4.0"
+	id "com.diffplug.gradle.spotless" version "3.18.0"
 	id 'org.sonarqube' version '2.6.2'
 	// id "io.codearte.nexus-staging" version "0.12.0"
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -55,7 +55,7 @@
 		<module name="UnusedImports">
 			<property name="processJavadoc" value="true" />
 		</module>
-		
+
 		<!-- Checks for metrics -->
 
 		<!-- Checks for Size Violations. -->
@@ -128,7 +128,9 @@
 
 		<!-- Miscellaneous other checks. -->
 		<module name="ArrayTypeStyle" />
-		<module name="AvoidEscapedUnicodeCharacters"/>
+		<module name="AvoidEscapedUnicodeCharacters">
+			<property name="allowEscapesForControlCharacters" value="true"/>
+		</module>
 		<module name="CommentsIndentation"/>
 		<module name="FinalParameters" />
 		<!-- Skipping indentation until https://github.com/checkstyle/checkstyle/issues/3342 is resolved
@@ -145,6 +147,6 @@
 	</module>
 
 	<module name="SuppressionFilter">
-		<property name="file" value="config/checkstyle/suppressions.xml" />
+		<property name="file" value="${config_loc}/suppressions.xml" />
 	</module>
 </module>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 project.ext.versions = [
-    checkstyle: '7.6.1',
+    checkstyle: '8.18',
     atlas: '5.5.0',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
@@ -12,4 +12,3 @@ project.ext.packages = [
     ],
     snappy: "org.xerial.snappy:snappy-java:${versions.snappy}",
 ]
-

--- a/gradle/execution.gradle
+++ b/gradle/execution.gradle
@@ -1,37 +1,49 @@
-task downloadPbf << {
-    mkdir "${buildDir}/example/data/pbfSource/"
-    ant.get(src: "https://apple.box.com/shared/static/1wj4fiuwg88dczgkwxrva8udbbqjn6y5.pbf",
-        dest: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
-        skipexisting: 'true')
+task downloadPbf {
+    doLast {
+        mkdir "${buildDir}/example/data/pbfSource/"
+        ant.get(src: "https://apple.box.com/shared/static/1wj4fiuwg88dczgkwxrva8udbbqjn6y5.pbf",
+            dest: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
+            skipexisting: 'true')
+    }
 }
 
-task downloadBoundaries << {
-    mkdir "${buildDir}/example/data/"
-    ant.get(src: "https://apple.box.com/shared/static/k06amjcm32p83klwd5roex3m8vxj0mvx.gz",
-        dest: "${buildDir}/example/data/boundaries.txt.gz",
-        skipexisting: 'true')
+task downloadBoundaries {
+    doLast {
+        mkdir "${buildDir}/example/data/"
+        ant.get(src: "https://apple.box.com/shared/static/k06amjcm32p83klwd5roex3m8vxj0mvx.gz",
+            dest: "${buildDir}/example/data/boundaries.txt.gz",
+            skipexisting: 'true')
+    }
 }
 
-task downloadShardingTree << {
-    mkdir "${buildDir}/example/data/"
-    ant.get(src: "https://apple.box.com/shared/static/2p2nz3khyusaup3mdxmuyr4mifwx1bmx.txt",
-        dest: "${buildDir}/example/data/sharding.txt",
-        skipexisting: 'true')
+task downloadShardingTree {
+    doLast {
+        mkdir "${buildDir}/example/data/"
+        ant.get(src: "https://apple.box.com/shared/static/2p2nz3khyusaup3mdxmuyr4mifwx1bmx.txt",
+            dest: "${buildDir}/example/data/sharding.txt",
+            skipexisting: 'true')
+    }
 }
 
-task copyShard1 (dependsOn: 'downloadPbf') << {
+task copyShard1 (dependsOn: 'downloadPbf') {
+    doLast {
     ant.copy(file: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
         toFile: "${buildDir}/example/data/pbfs/7-32-57.pbf")
+    }
 }
 
-task copyShard2 (dependsOn: 'downloadPbf') << {
-    ant.copy(file: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
-        toFile: "${buildDir}/example/data/pbfs/8-64-116.pbf")
+task copyShard2 (dependsOn: 'downloadPbf') {
+    doLast {
+        ant.copy(file: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
+            toFile: "${buildDir}/example/data/pbfs/8-64-116.pbf")
+    }
 }
 
-task copyShard3 (dependsOn: 'downloadPbf') << {
-    ant.copy(file: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
-        toFile: "${buildDir}/example/data/pbfs/8-65-116.pbf")
+task copyShard3 (dependsOn: 'downloadPbf') {
+    doLast {
+        ant.copy(file: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
+            toFile: "${buildDir}/example/data/pbfs/8-65-116.pbf")
+    }
 }
 
 task runGenerator(type: JavaExec, dependsOn: 'assemble', description: 'Executes the Atlas Generator Spark job.') {
@@ -74,6 +86,6 @@ task run(dependsOn: ['assemble',
         runGenerator.getCommandLine().each {
             line -> println("$line \\")
         }
-        runGenerator.execute()
     }
 }
+run.finalizedBy(runGenerator)

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -26,7 +26,7 @@ test
 }
 
 task integrationTest(type: Test) {
-    testClassesDir = sourceSets.integrationTest.output.classesDir
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     testLogging
     {
@@ -50,11 +50,11 @@ configurations
 
 spotless {
    java {
-      importOrder(['static java', 'static javax', 'static org', 'static com', 'static scala', 'java', 'javax', 'org', 'com', 'scala'])
+      importOrder 'static java', 'static javax', 'static org', 'static com', 'static scala', 'java', 'javax', 'org', 'com', 'scala'
       // JDK 11 Hack: https://github.com/junit-team/junit5/commit/f39ba8d1e7b479bfd2f137f3b85cdeeb91ded22c
-      if (org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8) {
+      //if (org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8) {
           removeUnusedImports()
-      }
+      //}
       eclipse().configFile 'config/format/code_format.xml'
    }
 }

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -51,10 +51,7 @@ configurations
 spotless {
    java {
       importOrder 'static java', 'static javax', 'static org', 'static com', 'static scala', 'java', 'javax', 'org', 'com', 'scala'
-      // JDK 11 Hack: https://github.com/junit-team/junit5/commit/f39ba8d1e7b479bfd2f137f3b85cdeeb91ded22c
-      //if (org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8) {
-          removeUnusedImports()
-      //}
+      removeUnusedImports()
       eclipse().configFile 'config/format/code_format.xml'
    }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -129,7 +129,8 @@ public class AtlasGenerator extends SparkJob
         final String shardingName = (String) command.get(AtlasGeneratorParameters.SHARDING_TYPE);
         final Sharding sharding = AtlasSharding.forString(shardingName, configuration());
         final Sharding pbfSharding = pbfShardingName != null
-                ? AtlasSharding.forString(pbfShardingName, configuration()) : sharding;
+                ? AtlasSharding.forString(pbfShardingName, configuration())
+                : sharding;
         final PbfContext pbfContext = new PbfContext(pbfPath, pbfSharding, pbfScheme);
         final String shouldAlwaysSliceConfiguration = (String) command
                 .get(AtlasGeneratorParameters.SHOULD_ALWAYS_SLICE_CONFIGURATION);

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -163,7 +163,8 @@ public final class AtlasGeneratorParameters
         final String waySectioningConfiguration = (String) command
                 .get(WAY_SECTIONING_CONFIGURATION);
         propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null
-                ? null : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
+                ? null
+                : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
 
         final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
         propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
@@ -174,8 +175,9 @@ public final class AtlasGeneratorParameters
                 : FileSystemHelper.resource(pbfWayConfiguration, sparkContext).all());
 
         final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
-        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null
-                ? null : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
+        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
+                pbfRelationConfiguration == null ? null
+                        : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
 
         return propertyMap;
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
@@ -234,7 +234,8 @@ public class RawAtlasCreator extends Command
         final String shardingName = (String) command.get(SHARDING_TYPE);
         final Sharding sharding = AtlasSharding.forString(shardingName, Maps.stringMap());
         final Sharding pbfSharding = pbfShardingName != null
-                ? AtlasSharding.forString(shardingName, Maps.stringMap()) : sharding;
+                ? AtlasSharding.forString(shardingName, Maps.stringMap())
+                : sharding;
         final String countryName = (String) command.get(COUNTRY);
         final File output = (File) command.get(OUTPUT);
         final RawAtlasFlavor atlasFlavor = (RawAtlasFlavor) command.get(ATLAS_FLAVOR);


### PR DESCRIPTION
### Description:

Upgrade gradle to 5.

Related necessary updates:
- Gradle wrapper 5.2.1
- Checkstyle 8.18
  - Some checks that were already enabled started working, so fixed the related issues.
- Spotless 3.18.0
  - No need to remove removeUnusedImports anymore
  - `importOrder([ x, y, z])` becomes `importOrder x, y, z`
- gradle run updates
  - The double left `<<` is now invalid. Replaced by `doLast{...}`
  - `runGenerator.execute()` is invalid. Replaced by `run.finalizedBy(runGenerator)` at the end.
- Added maven central badge

### Potential Impact:

The impact should be confined to this repository.

### Unit Test Approach:

Use existing tests.

### Test Results:

Use existing tests.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)