### PR TITLE
Run integration tests for PR builds as well

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -12,10 +12,5 @@ else
 	echo "Not a manual release"
 fi
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ];
-then
-	echo "Skip integration tests in pull request builds"
-	./gradlew clean build -x integrationTest
-else
-	./gradlew clean build
-fi
+
+./gradlew clean build


### PR DESCRIPTION
### Description:

Integration tests were only being run on release builds, not PRs. This meant that a PR with a breaking integration test change would be merged with a build passing marker.

### Potential Impact:

Will run integration tests for all builds, not just release builds.

### Unit Test Approach:

This PR build passing

### Test Results:

We will see!

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
