### PR TITLE
Added in configuration option for filtered output

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -83,11 +83,11 @@ public class AtlasGeneratorIntegrationTest
                     new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-233.ldgeojson.gz")));
             Assert.assertTrue(resourceFileSystem.exists(
                     new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-234.ldgeojson.gz")));
-            Assert.assertEquals(405,
+            Assert.assertEquals(402,
                     Iterables.size(resourceForName(resourceFileSystem,
                             LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-234.ldgeojson.gz")
                                     .lines()));
-            Assert.assertEquals(405,
+            Assert.assertEquals(402,
                     Iterables.size(resourceForName(resourceFileSystem,
                             LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-233.ldgeojson.gz")
                                     .lines()));

--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -83,11 +83,11 @@ public class AtlasGeneratorIntegrationTest
                     new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-233.ldgeojson.gz")));
             Assert.assertTrue(resourceFileSystem.exists(
                     new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-234.ldgeojson.gz")));
-            Assert.assertEquals(402,
+            Assert.assertEquals(405,
                     Iterables.size(resourceForName(resourceFileSystem,
                             LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-234.ldgeojson.gz")
                                     .lines()));
-            Assert.assertEquals(402,
+            Assert.assertEquals(405,
                     Iterables.size(resourceForName(resourceFileSystem,
                             LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-233.ldgeojson.gz")
                                     .lines()));

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
@@ -63,7 +63,14 @@ public enum AtlasGeneratorJobGroup
             "Atlas Deltas Creation",
             "deltas",
             AtlasDelta.class,
-            RemovedMultipleAtlasDeltaOutputFormat.class);
+            RemovedMultipleAtlasDeltaOutputFormat.class),
+
+    TAGGABLE_FILTERED_OUTPUT(
+            8,
+            "Taggable Filtered SubAtlas Creation",
+            "filteredOutput",
+            Atlas.class,
+            MultipleAtlasOutputFormat.class);
 
     private final String description;
     private final Integer identifier;

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -82,6 +82,13 @@ public final class AtlasGeneratorParameters
                     + " always be attempted regardless of the number of countries it intersects according to the"
                     + " country boundary map's grid index.",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
+
+    public static final Switch<String> SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION = new Switch<>(
+            "shouldIncludeFilteredOutputConfiguration",
+            "The path to the configuration file that defines which will be included in filtered output."
+                    + " Filtered output will only be generated if this switch is specificed, and will be"
+                    + " stored in a separate subdirectory.",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<Boolean> USE_JAVA_FORMAT = new Switch<>("useJavaFormat",
             "Generate the atlas files using the java serialization atlas format (as opposed to the protobuf format).",
             Boolean::parseBoolean, Optionality.OPTIONAL, "false");
@@ -188,7 +195,8 @@ public final class AtlasGeneratorParameters
                 PBF_SHARDING, PREVIOUS_OUTPUT_FOR_DELTA, CODE_VERSION, DATA_VERSION,
                 EDGE_CONFIGURATION, WAY_SECTIONING_CONFIGURATION, PBF_NODE_CONFIGURATION,
                 PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, ATLAS_SCHEME,
-                SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT, LINE_DELIMITED_GEOJSON_OUTPUT);
+                SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT, LINE_DELIMITED_GEOJSON_OUTPUT,
+                SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION);
     }
 
     private AtlasGeneratorParameters()


### PR DESCRIPTION
### Description:

Adds an option to create a separate, filtered output after final Atlas generation is finished. If no filter is provided, the filtering step will not be run. If a filter is provided, it should be in the form of a JSON taggable filter file; after Atlas generation, all generated Atlas files will be written to the 'filteredOutput' subdirectory using a SOFT_CUT subatlas call. 

### Potential Impact:
None, as there are no changes if the filter is not provided.

### Unit Test Approach:

Describe unit tests being added with that PR.

### Test Results:

Describe other (non-unit) test results here.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)