### PR TITLE
Dump ResourceFileSystem to disk

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.util.Progressable;
 import org.apache.spark.SparkConf;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.streaming.resource.ByteArrayResource;
+import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
 import org.openstreetmap.atlas.utilities.collections.StringList;
@@ -64,6 +65,16 @@ public class ResourceFileSystem extends FileSystem
         final Configuration result = new Configuration();
         result.set(RESOURCE_FILE_SYSTEM_CONFIGURATION, ResourceFileSystem.class.getCanonicalName());
         return result;
+    }
+
+    public static void dumpToDisk(final File folder)
+    {
+        files().forEach(file ->
+        {
+            final String subPath = file.substring(String.valueOf(SCHEME + "://").length());
+            final File output = folder.child(subPath);
+            STORE.get(file).copyTo(output);
+        });
     }
 
     public static Set<String> files()

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/ResourceFileSystemTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/ResourceFileSystemTest.java
@@ -1,0 +1,34 @@
+package org.openstreetmap.atlas.generator.tools.streaming.resource;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+
+/**
+ * @author matthieun
+ */
+public class ResourceFileSystemTest
+{
+    @Test
+    public void testDumpToDisk()
+    {
+        ResourceFileSystem.addResource(ResourceFileSystem.SCHEME + "://test/123",
+                new StringResource("123"));
+        ResourceFileSystem.addResource(ResourceFileSystem.SCHEME + "://test/abc/456",
+                new StringResource("456"));
+        final File tempFolder = File.temporaryFolder();
+        try
+        {
+            tempFolder.mkdirs();
+            ResourceFileSystem.dumpToDisk(tempFolder);
+            Assert.assertEquals("123", tempFolder.child("test/123").all());
+            Assert.assertEquals("456", tempFolder.child("test/abc/456").all());
+        }
+        finally
+        {
+            tempFolder.deleteRecursively();
+        }
+    }
+}


### PR DESCRIPTION
### Description:

Allow for saving a test `ResourceFileSystem` to disk.

### Potential Impact:

New feature.

### Unit Test Approach:

Added one unit test.

### Test Results:

Test passes

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)