### PR TITLE
Update Missing Shard Verifier to use configurable way filter

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
@@ -251,7 +251,7 @@ public class AtlasMissingShardVerifier extends Command
         final Set<CountryShard> missingCountryShards = missingShardFile.linesList().stream()
                 .map(CountryShard::forName).collect(Collectors.toSet());
         final File wayFilterFile = (File) command.get(WAY_FILTER);
-        ConfiguredTaggableFilter wayFilter;
+        final ConfiguredTaggableFilter wayFilter;
         if (wayFilterFile != null)
         {
             wayFilter = new ConfiguredTaggableFilter(new StandardConfiguration(wayFilterFile));


### PR DESCRIPTION
### Description:

Added an optional switch to the `AtlasMissingShardVerifier` that takes a configurable way filter. If no filter is provided, it will default to the osm-pbf-way filter which is a resource in the atlas project.

### Potential Impact:

Allows verification to match the atlas generation configuration for way ingest.

### Unit Test Approach:

Tested locally passing a configuration, and also using the default value.

### Test Results:

Switch works as intended.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)