### PR TITLE
Fixed RawAtlasCountrySlicer constructors, added edge-only subatlas caching

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '8.18',
-    atlas: '5.5.4',
+    atlas: '5.5.5',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '8.18',
-    atlas: '5.5.3',
+    atlas: '5.5.4',
     spark: '1.6.0-cdh5.7.0',
     snappy: '1.1.1.6',
 ]

--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/slicing/DynamicRelationSlicingIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/slicing/DynamicRelationSlicingIntegrationTest.java
@@ -15,6 +15,7 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
 import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
+import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.raw.slicing.RawAtlasCountrySlicer;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.geography.sharding.CountryShard;
@@ -94,9 +95,12 @@ public class DynamicRelationSlicingIntegrationTest
                 initialShardDEF.getShard());
 
         // the operation we are testing
-        final Atlas relationSlicedAtlasDEF = new RawAtlasCountrySlicer("DEF", boundaryMap, sharding,
+
+        final Atlas relationSlicedAtlasDEF = new RawAtlasCountrySlicer(AtlasLoadingOption
+                .createOptionWithAllEnabled(boundaryMap).setAdditionalCountryCodes("DEF"), sharding,
                 atlasFetcherDEF).sliceRelations(initialShardDEF.getShard());
-        final Atlas relationSlicedAtlasABC = new RawAtlasCountrySlicer("ABC", boundaryMap, sharding,
+        final Atlas relationSlicedAtlasABC = new RawAtlasCountrySlicer(AtlasLoadingOption
+                .createOptionWithAllEnabled(boundaryMap).setAdditionalCountryCodes("ABC"), sharding,
                 atlasFetcherABC).sliceRelations(initialShardABC.getShard());
 
         // Sum the areas and check it is the size expected

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
@@ -34,43 +34,42 @@ public enum AtlasGeneratorJobGroup
             "fullySlicedAtlas",
             Atlas.class,
             MultipleAtlasOutputFormat.class),
-    WAY_SECTIONED(
+    EDGE_SUB(
             4,
+            "Edge-only Sub Atlas Creation",
+            "edgeOnlySubAtlas",
+            Atlas.class,
+            MultipleAtlasOutputFormat.class),
+    WAY_SECTIONED(
+            5,
             "Way Sectioned Atlas Creation",
             "atlas",
             Atlas.class,
             MultipleAtlasOutputFormat.class),
     WAY_SECTIONED_PBF(
-            4,
+            5,
             "Way Sectioned Atlas Creation",
             "atlas",
             Atlas.class,
             MultipleAtlasProtoOutputFormat.class),
     SHARD_STATISTICS(
-            5,
+            6,
             "Shard Statistics Creation",
             "shardStats",
             AtlasStatistics.class,
             MultipleAtlasStatisticsOutputFormat.class),
     COUNTRY_STATISTICS(
-            6,
+            7,
             "Country Statistics Creations",
             "countryStats",
             AtlasStatistics.class,
             MultipleAtlasCountryStatisticsOutputFormat.class),
     DELTAS(
-            7,
+            8,
             "Atlas Deltas Creation",
             "deltas",
             AtlasDelta.class,
-            RemovedMultipleAtlasDeltaOutputFormat.class),
-
-    TAGGABLE_FILTERED_OUTPUT(
-            8,
-            "Taggable Filtered SubAtlas Creation",
-            "filteredOutput",
-            Atlas.class,
-            MultipleAtlasOutputFormat.class);
+            RemovedMultipleAtlasDeltaOutputFormat.class);
 
     private final String description;
     private final Integer identifier;

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
@@ -69,7 +69,13 @@ public enum AtlasGeneratorJobGroup
             "Atlas Deltas Creation",
             "deltas",
             AtlasDelta.class,
-            RemovedMultipleAtlasDeltaOutputFormat.class);
+            RemovedMultipleAtlasDeltaOutputFormat.class),
+    TAGGABLE_FILTERED_OUTPUT(
+            9,
+            "Taggable Filtered SubAtlas Creation",
+            "filteredOutput",
+            Atlas.class,
+            MultipleAtlasOutputFormat.class);
 
     private final String description;
     private final Integer identifier;

--- a/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/creator/RawAtlasCreator.java
@@ -323,14 +323,18 @@ public class RawAtlasCreator extends Command
             final CountryBoundaryMap countryBoundaryMap, final Sharding sharding,
             final Function<Shard, Optional<Atlas>> lineSlicedAtlasFetcher)
     {
-        return new RawAtlasCountrySlicer(countryName, countryBoundaryMap, sharding,
-                lineSlicedAtlasFetcher).sliceRelations(shardToBuild);
+        return new RawAtlasCountrySlicer(
+                AtlasLoadingOption.createOptionWithAllEnabled(countryBoundaryMap)
+                        .setAdditionalCountryCodes(countryName),
+                sharding, lineSlicedAtlasFetcher).sliceRelations(shardToBuild);
     }
 
     private Atlas generateLineSlicedAtlas(final String countryName,
             final CountryBoundaryMap countryBoundaryMap, final Atlas rawAtlas)
     {
-        return new RawAtlasCountrySlicer(countryName, countryBoundaryMap).sliceLines(rawAtlas);
+        return new RawAtlasCountrySlicer(
+                AtlasLoadingOption.createOptionWithAllEnabled(countryBoundaryMap)
+                        .setAdditionalCountryCodes(countryName)).sliceLines(rawAtlas);
     }
 
     private Atlas generateRawAtlas(final String pbfPath, final Shard shardToBuild)

--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
@@ -192,9 +192,7 @@ public class WorldAtlasGenerator extends Command
                 .withMetaData(metaData).build();
         if (loadingOptions.isCountrySlicing())
         {
-            atlas = new RawAtlasCountrySlicer(
-                    loadingOptions.getCountryBoundaryMap().getLoadedCountries(),
-                    loadingOptions.getCountryBoundaryMap()).slice(atlas);
+            atlas = new RawAtlasCountrySlicer(loadingOptions).slice(atlas);
         }
         if (loadingOptions.isWaySectioning())
         {


### PR DESCRIPTION
### Description:
This PR fixes compile issues with a recent change to the constructor of RawAtlasCountrySlicer. The constructor now takes a single AtlasLoadingOption, and uses the CountryBoundaryMap, Countries, and EdgeFilter from it to set up country slicing.

Additionally, way-sectioning now creates a separate folder for edge-only Atlases, in order to speed up way section performance during dynamic Atlas expansion during way-sectioning.

### Potential Impact:

No data changes, so minimal impact.

### Unit Test Approach:

Describe unit tests being added with that PR.

### Test Results:

Describe other (non-unit) test results here.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)