### PR TITLE
Simplification and cleanup of SparkJob

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/tools/spark/SparkJobIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/tools/spark/SparkJobIntegrationTest.java
@@ -1,0 +1,63 @@
+package org.openstreetmap.atlas.generator.tools.spark;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.runtime.CommandMap;
+
+/**
+ * @author matthieun
+ */
+public class SparkJobIntegrationTest
+{
+    @Test
+    public void test() throws IOException
+    {
+        final SparkJob sparkJob = new SparkJob()
+        {
+            private static final long serialVersionUID = -6657905234445292742L;
+
+            @Override
+            public String getName()
+            {
+                return "SparkJobIntegrationTest";
+            }
+
+            @Override
+            public void start(final CommandMap command)
+            {
+                // Do nothing.
+            }
+        };
+
+        sparkJob.runWithoutQuitting(getArguments());
+
+        try (ResourceFileSystem resourceFileSystem = new ResourceFileSystem())
+        {
+            Assert.assertTrue(resourceFileSystem.exists(new Path("resource://blah/_SUCCESS")));
+        }
+    }
+
+    private String[] getArguments()
+    {
+        final StringList sparkConfiguration = new StringList();
+        ResourceFileSystem.simpleconfiguration().entrySet().stream()
+                .forEach(entry -> sparkConfiguration.add(entry.getKey() + "=" + entry.getValue()));
+
+        final StringList arguments = new StringList();
+        arguments.add("-master=local");
+        arguments.add("-output=resource://blah");
+        arguments.add("-sparkOptions=" + sparkConfiguration.join(","));
+
+        final String[] args = new String[arguments.size()];
+        for (int i = 0; i < arguments.size(); i++)
+        {
+            args[i] = arguments.get(i);
+        }
+        return args;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
@@ -1,7 +1,6 @@
 package org.openstreetmap.atlas.generator.tools.spark;
 
 import java.io.BufferedWriter;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Serializable;
@@ -9,8 +8,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.regex.Pattern;
+import java.util.Map.Entry;
+import java.util.function.UnaryOperator;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -55,9 +54,6 @@ public abstract class SparkJob extends Command implements Serializable
             StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<String> OUTPUT = new Switch<>("output",
             "Output path of the Spark Job", StringConverter.IDENTITY, Optionality.REQUIRED);
-    public static final Switch<String> STARTED_FOLDER = new Switch<>("startedFolder",
-            "Folder where the spark job will write the \"_STARTED\" file.",
-            StringConverter.IDENTITY, Optionality.REQUIRED);
     public static final Switch<String> MASTER = new Switch<>("master", "The spark master URL",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<Map<String, String>> SPARK_OPTIONS = new Switch<>("sparkOptions",
@@ -74,14 +70,8 @@ public abstract class SparkJob extends Command implements Serializable
             "sparkContextProvider", "The class name of the Spark Context Provider",
             new SparkContextProviderFinder(), Optionality.OPTIONAL,
             DefaultSparkContextProvider.class.getCanonicalName());
-    public static final Switch<Pattern> SENSITIVE_CONFIGURATION_PATTERN = new Switch<>(
-            "sensitiveConfiguration",
-            "Regular expression pattern of spark configuration keys to avoid logging.",
-            Pattern::compile, Optionality.OPTIONAL, ".*");
 
     public static final String SUCCESS_FILE = "_SUCCESS";
-    public static final String STARTED_FILE = "_STARTED";
-    public static final String EXITED_FILE = "_EXITED";
     public static final String FAILED_FILE = "_FAILED";
     public static final String SAVING_SEPARATOR = "-";
 
@@ -134,28 +124,14 @@ public abstract class SparkJob extends Command implements Serializable
         @SuppressWarnings("unchecked")
         final Map<String, String> additionalOptions = (Map<String, String>) command
                 .get(ADDITIONAL_SPARK_OPTIONS);
-        final Pattern sensitiveConfiguration = (Pattern) command
-                .get(SENSITIVE_CONFIGURATION_PATTERN);
         // The additional options take precedence
-        additionalOptions.forEach((key, value) -> options.put(key, value));
+        additionalOptions.forEach(options::put);
 
         // Initialize Spark
         final SparkConf configuration = new SparkConf().setAppName(getName());
-        for (final String key : options.keySet())
-        {
-            final String value = options.get(key);
-            if (!sensitiveConfiguration.matcher(key).matches())
-            {
-                logger.info("Forcing configuration from -{}: key: \"{}\", value: \"{}\"",
-                        SPARK_OPTIONS.getName(), key, value);
-            }
-            else
-            {
-                logger.info("Forcing configuration from -{}: key: \"{}\", value: \"**********\"",
-                        SPARK_OPTIONS.getName(), key);
-            }
-            configuration.set(key, value);
-        }
+        options.forEach(configuration::set);
+        logOptions(options);
+
         if (sparkMaster != null)
         {
             configuration.setMaster(sparkMaster);
@@ -163,61 +139,26 @@ public abstract class SparkJob extends Command implements Serializable
         configuration.set("spark.serializer", JavaSerializer.class.getCanonicalName());
         configuration.set(org.apache.hadoop.mapreduce.lib.output.FileOutputFormat.COMPRESS,
                 (String) command.get(COMPRESS_OUTPUT));
-        logger.info("SparkConf ===============================================================");
-        for (final Tuple2<String, String> tuple : configuration.getAll())
-        {
-            if (!sensitiveConfiguration.matcher(tuple._1()).matches())
-            {
-                logger.info("SparkConf: key: \"{}\", value: \"{}\"", tuple._1(), tuple._2());
-            }
-            else
-            {
-                logger.info("SparkConf: key: \"{}\", value: \"**********\"", tuple._1());
-            }
-        }
-        logger.info("SparkConf ===============================================================");
-        this.context = ((SparkContextProvider) command.get(SPARK_CONTEXT_PROVIDER))
-                .apply(configuration);
-        // Add all the configuration items to the hadoop configuration too.
-        for (final String key : options.keySet())
-        {
-            final String value = options.get(key);
-            this.context.hadoopConfiguration().set(key, value);
-        }
 
         // Main function
         final String output = output(command);
-        final String started = (String) command.get(STARTED_FOLDER);
-        try
+        try (JavaSparkContext localcontext = ((SparkContextProvider) command
+                .get(SPARK_CONTEXT_PROVIDER)).apply(configuration))
         {
-            checkFileDoesNotExists(started, STARTED_FILE);
-            writeStatus(started, STARTED_FILE, "Started!");
+            this.context = localcontext;
+            // Add all the configuration items to the hadoop configuration too.
+            final Configuration hadoopConfiguration = this.context.hadoopConfiguration();
+            options.forEach(hadoopConfiguration::set);
+
             FileSystemPerformanceHelper.openRenamePool();
             start(command);
             FileSystemPerformanceHelper.waitForAndCloseRenamePool();
-            deleteStatus(started, STARTED_FILE);
             writeStatus(output, SUCCESS_FILE, "Success!");
         }
-        catch (final Exception exception)
+        catch (final Exception e)
         {
-            logger.error("Unable to prepare output directories.", exception);
-            try
-            {
-                writeStatus(output, FAILED_FILE, "Failed!");
-                deleteStatus(started, STARTED_FILE);
-            }
-            catch (final Exception exception2)
-            {
-                logger.error("Unable to cleanup output directories after error.", exception2);
-                writeStatus(output, FAILED_FILE, "Failed!");
-            }
-            throw exception;
-        }
-        finally
-        {
-            // Close
-            this.context.stop();
-            this.context.close();
+            writeStatus(output, FAILED_FILE, "Failed!");
+            throw new CoreException("Job {} failed.", getName(), e);
         }
         return 0;
     }
@@ -351,7 +292,7 @@ public abstract class SparkJob extends Command implements Serializable
     protected <T> void splitAndSaveAsHadoopFile(final JavaPairRDD<String, T> input,
             final String path, final Class<T> valueClass,
             final Class<? extends MultipleOutputFormat<String, T>> formatterClass,
-            final Function<String, String> keyReducer)
+            final UnaryOperator<String> keyReducer)
     {
         // Get all the represented names.
         final List<String> splitNames = input.keys().map(keyReducer::apply).distinct().collect();
@@ -366,58 +307,27 @@ public abstract class SparkJob extends Command implements Serializable
     @Override
     protected SwitchList switches()
     {
-        return new SwitchList().with(INPUT, OUTPUT, STARTED_FOLDER, MASTER, SPARK_OPTIONS,
-                ADDITIONAL_SPARK_OPTIONS, COMPRESS_OUTPUT, SPARK_CONTEXT_PROVIDER,
-                SENSITIVE_CONFIGURATION_PATTERN);
+        return new SwitchList().with(INPUT, OUTPUT, MASTER, SPARK_OPTIONS, ADDITIONAL_SPARK_OPTIONS,
+                COMPRESS_OUTPUT, SPARK_CONTEXT_PROVIDER);
     }
 
-    private void checkFileDoesNotExists(final String path, final String name)
-    {
-        boolean fileIsThere = false;
-        try
-        {
-            final FileSystem fileSystem = getFileSystem(path);
-            try
-            {
-                fileSystem.getFileStatus(new Path(SparkFileHelper.combine(path, name)));
-                fileIsThere = true;
-            }
-            catch (final FileNotFoundException e)
-            {
-                // File is not there.
-            }
-        }
-        catch (final Exception e)
-        {
-            throw new CoreException("Could not check {}/{} file.", path, name, e);
-        }
-        if (fileIsThere)
-        {
-            throw new CoreException("File {}/{} exists, even though it should not.", path, name);
-        }
-    }
-
-    private void deleteStatus(final String path)
-    {
-        try
-        {
-            final FileSystem fileSystem = getFileSystem(path);
-            fileSystem.delete(new Path(path), false);
-        }
-        catch (final Exception e)
-        {
-            throw new CoreException("Could not delete {}", path, e);
-        }
-    }
-
-    private void deleteStatus(final String path, final String name)
-    {
-        deleteStatus(SparkFileHelper.combine(path, name));
-    }
-
-    private FileSystem getFileSystem(final String path) throws IllegalArgumentException, IOException
+    private FileSystem getFileSystem(final String path) throws IOException
     {
         return new Path(path).getFileSystem(configuration());
+    }
+
+    private void logOptions(final Map<String, String> options)
+    {
+        if (logger.isInfoEnabled())
+        {
+            for (final Entry<String, String> entry : options.entrySet())
+            {
+                final String key = entry.getKey();
+                final String value = entry.getValue();
+                logger.info("Forcing configuration from -{}: key: \"{}\", value: \"{}\"",
+                        SPARK_OPTIONS.getName(), key, value);
+            }
+        }
     }
 
     private void writeStatus(final String path, final String name, final String contents)


### PR DESCRIPTION
### Description:

Simplification and cleanup of the SparkJob class. The StartedFolder is removed and logging is simplified. Also removed a bunch of sonar errors.

### Potential Impact:

Some downstream jobs relying on some switches might have to be updated.

### Unit Test Approach:

Added one simple integration test.

### Test Results:

Tests pass.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
