### PR TITLE
Added in support for slicing configuration override

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -218,9 +218,12 @@ public class AtlasGenerator extends SparkJob
         }
 
         // Subatlas the raw shard Atlas files based on water relations
+        final Predicate<Taggable> slicingFilter = AtlasGeneratorParameters
+                .buildAtlasLoadingOption(broadcastBoundaries.getValue(),
+                        broadcastLoadingOptions.getValue())
+                .getSlicingFilter();
         final JavaPairRDD<String, Atlas> lineSlicedSubAtlasRDD = lineSlicedAtlasRDD
-                .mapToPair(AtlasGeneratorHelper.subatlas(AtlasGeneratorHelper.subAtlasFilter,
-                        AtlasCutType.SILK_CUT))
+                .mapToPair(AtlasGeneratorHelper.subatlas(slicingFilter, AtlasCutType.SILK_CUT))
                 .filter(tuple -> tuple._2() != null);
         lineSlicedSubAtlasRDD.cache();
         saveAsHadoop(lineSlicedSubAtlasRDD, AtlasGeneratorJobGroup.LINE_SLICED_SUB, output);

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -21,7 +21,6 @@ import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
-import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.raw.sectioning.WaySectionProcessor;
@@ -34,10 +33,7 @@ import org.openstreetmap.atlas.geography.sharding.CountryShard;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.Resource;
-import org.openstreetmap.atlas.tags.NaturalTag;
-import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.tags.Taggable;
-import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.runtime.system.memory.Memory;
 import org.openstreetmap.atlas.utilities.time.Time;
@@ -90,16 +86,6 @@ public final class AtlasGeneratorHelper implements Serializable
     private static final Logger logger = LoggerFactory.getLogger(AtlasGeneratorHelper.class);
     private static final String LINE_SLICED_SUBATLAS_NAMESPACE = "lineSlicedSubAtlas";
     private static final String LINE_SLICED_ATLAS_NAMESPACE = "lineSlicedAtlas";
-
-    // Bring in all lines that will become edges
-    static final Predicate<Taggable> relationPredicate = entity -> entity instanceof Relation
-            && Validators.isOfType(entity, NaturalTag.class, NaturalTag.WATER)
-            && Validators.isOfType(entity, RelationTypeTag.class, RelationTypeTag.MULTIPOLYGON);
-
-    // Dynamic expansion filter will be a combination of points and lines
-    @SuppressWarnings("unchecked")
-    public static final Predicate<Taggable> subAtlasFilter = (Predicate<Taggable> & Serializable) entity -> relationPredicate
-            .test(entity);
 
     private static final AtlasResourceLoader ATLAS_LOADER = new AtlasResourceLoader();
 

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -64,6 +64,10 @@ public final class AtlasGeneratorParameters
             "waySectioningConfiguration",
             "The path to the configuration file that defines where to section Ways to make Edges.",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
+
+    public static final Switch<String> SLICING_CONFIGURATION = new Switch<>("slicingConfiguration",
+            "The path to the configuration file that defines which relations to dynamically expand when slicing.",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<String> PBF_WAY_CONFIGURATION = new Switch<>(
             "osmPbfWayConfiguration",
             "The path to the configuration file that defines which PBF Ways becomes an Atlas Entity.",
@@ -153,6 +157,13 @@ public final class AtlasGeneratorParameters
                     getTaggableFilterFrom(new StringResource(pbfRelationConfiguration)));
         }
 
+        final String slicingConfiguration = properties.get(SLICING_CONFIGURATION.getName());
+        if (slicingConfiguration != null)
+        {
+            atlasLoadingOption.setSlicingFilter(
+                    getTaggableFilterFrom(new StringResource(slicingConfiguration)));
+        }
+
         return atlasLoadingOption;
     }
 
@@ -186,6 +197,10 @@ public final class AtlasGeneratorParameters
                 pbfRelationConfiguration == null ? null
                         : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
 
+        final String slicingConfiguration = (String) command.get(SLICING_CONFIGURATION);
+        propertyMap.put(SLICING_CONFIGURATION.getName(), slicingConfiguration == null ? null
+                : FileSystemHelper.resource(slicingConfiguration, sparkContext).all());
+
         return propertyMap;
     }
 
@@ -194,9 +209,9 @@ public final class AtlasGeneratorParameters
         return new SwitchList().with(COUNTRIES, COUNTRY_SHAPES, SHARDING_TYPE, PBF_PATH, PBF_SCHEME,
                 PBF_SHARDING, PREVIOUS_OUTPUT_FOR_DELTA, CODE_VERSION, DATA_VERSION,
                 EDGE_CONFIGURATION, WAY_SECTIONING_CONFIGURATION, PBF_NODE_CONFIGURATION,
-                PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, ATLAS_SCHEME,
-                SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT, LINE_DELIMITED_GEOJSON_OUTPUT,
-                SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION);
+                PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, SLICING_CONFIGURATION,
+                ATLAS_SCHEME, SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT,
+                LINE_DELIMITED_GEOJSON_OUTPUT, SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION);
     }
 
     private AtlasGeneratorParameters()


### PR DESCRIPTION
### Description:
This PR allows for overriding the slicing configuration used to decide which relations will be dynamically expanded on during relation expansion. Default is the default from AtlasLoadingOption.

This PR requires [this PR from Atlas](https://github.com/osmlab/atlas/pull/438) to be merged and released before it will build properly.

### Potential Impact:
N/A

### Unit Test Approach:
N/A

### Test Results:
N/A
------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)