### PR TITLE
Check for corrupt PBFs

### DIFF
--- a/src/test/java/org/openstreetmap/atlas/generator/sharding/PbfVerifierTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/sharding/PbfVerifierTest.java
@@ -50,21 +50,15 @@ public class PbfVerifierTest
                 .parseSlippyTileFile(this.slippyTileFile);
 
         final PbfVerifier pbfVerifier = new PbfVerifier();
-
-        final List<String> pbfFileNames = new ArrayList<>();
-        pbfFileNames.add("10-313-380.pbf");
-        pbfFileNames.add("10-313-381.pbf");
-
         final Integer expectedPbfCount = Integer.parseInt(this.slippyTileFile.firstLine());
 
         // no pbfs are missing
-        int returnCode = pbfVerifier.checkForMissingPbfs(shardToBounds, pbfFileNames,
-                expectedPbfCount);
+        int returnCode = pbfVerifier.checkForMissingPbfs(shardToBounds, pbfFiles, expectedPbfCount);
         Assert.assertEquals(0, returnCode);
 
         // a pbf is now missing, the check should fail
-        pbfFileNames.remove("10-313-381.pbf");
-        returnCode = pbfVerifier.checkForMissingPbfs(shardToBounds, pbfFileNames, expectedPbfCount);
+        pbfFiles.remove(this.pbf2);
+        returnCode = pbfVerifier.checkForMissingPbfs(shardToBounds, pbfFiles, expectedPbfCount);
         Assert.assertEquals(1, returnCode);
     }
 


### PR DESCRIPTION
### Description:

Added a zero file size check to the `PbfVerifier`. Since PBF's that contain no data still contain metadata, any 0 byte PBF is a result of a write failure in the PBF generation process. Therefore, finding a size 0 PBF will cause the verifier to fail.

### Potential Impact:

`PbfVerifier` will fail on empty pbf files.

### Unit Test Approach:

Updated the `PbfVerifierTest` to accommodate the changes. Tested 0 size pbf detection locally.

### Test Results:

Tests ran successfully.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)