### PR TITLE
Tooling to save Sharding and Boundaries to output folder

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -396,7 +396,15 @@ public class AtlasGenerator extends SparkJob
     private Sharding pbfSharding(final CommandMap command)
     {
         final String pbfShardingName = (String) command.get(AtlasGeneratorParameters.PBF_SHARDING);
-        return sharding(pbfShardingName, command);
+        try
+        {
+            return sharding(pbfShardingName, command);
+        }
+        catch (final Exception e)
+        {
+            logger.warn("PBF Sharding unavailable, defaulting to atlas sharding.");
+        }
+        return atlasSharding(command);
     }
 
     private PersistenceTools persistenceTools()

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -249,8 +249,8 @@ public class AtlasGenerator extends SparkJob
         }
         catch (final Exception exception)
         {
-            logger.warn(EXCEPTION_MESSAGE, AtlasGeneratorJobGroup.WAY_SECTIONED.getDescription(),
-                    exception);
+            logger.warn(EXCEPTION_MESSAGE,
+                    AtlasGeneratorJobGroup.WAY_SECTIONED_PBF.getDescription(), exception);
         }
 
         if (lineDelimitedGeojsonOutput)
@@ -269,8 +269,8 @@ public class AtlasGenerator extends SparkJob
         }
         catch (final Exception exception)
         {
-            logger.warn(EXCEPTION_MESSAGE, AtlasGeneratorJobGroup.WAY_SECTIONED.getDescription(),
-                    exception);
+            logger.warn(EXCEPTION_MESSAGE,
+                    AtlasGeneratorJobGroup.WAY_SECTIONED_PBF.getDescription(), exception);
         }
         // Create the metrics
         final JavaPairRDD<String, AtlasStatistics> statisticsRDD = countryAtlasShardsRDD

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -17,6 +17,7 @@ import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenc
 import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
 import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
+import org.openstreetmap.atlas.generator.tools.spark.persistence.PersistenceTools;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
 import org.openstreetmap.atlas.geography.atlas.statistics.AtlasStatistics;
@@ -47,13 +48,11 @@ import scala.Tuple2;
 public class AtlasGenerator extends SparkJob
 {
 
+    public static final String LINE_DELIMITED_GEOJSON_STATISTICS_FOLDER = "ldgeojson";
     private static final long serialVersionUID = 5985696743749843135L;
     private static final Logger logger = LoggerFactory.getLogger(AtlasGenerator.class);
-
     private static final String SAVED_MESSAGE = "\n\n********** SAVED FOR STEP: {} **********\n";
     private static final String EXCEPTION_MESSAGE = "Exception after task {} :";
-
-    public static final String LINE_DELIMITED_GEOJSON_STATISTICS_FOLDER = "ldgeojson";
 
     public static void main(final String[] args)
     {
@@ -99,6 +98,17 @@ public class AtlasGenerator extends SparkJob
     public String getName()
     {
         return "Atlas Generator";
+    }
+
+    @Override
+    public void runAfter(final CommandMap command)
+    {
+        final Boolean copyToOutput = (Boolean) command.get(PersistenceTools.COPY_SHARDING_AND_BOUNDARIES);
+        final 
+        if (copyToOutput)
+        {
+            PersistenceTools.copyShardingAndBoundariesToOutput();
+        }
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -428,14 +428,14 @@ public final class AtlasGeneratorHelper implements Serializable
             catch (final Throwable e) // NOSONAR
             {
                 throw new CoreException(ERROR_MESSAGE,
-                        AtlasGeneratorJobGroup.WAY_SECTIONED.getDescription(), countryShardString,
-                        e);
+                        AtlasGeneratorJobGroup.WAY_SECTIONED_PBF.getDescription(),
+                        countryShardString, e);
             }
 
-            logger.info(FINISHED_MESSAGE, AtlasGeneratorJobGroup.WAY_SECTIONED.getDescription(),
+            logger.info(FINISHED_MESSAGE, AtlasGeneratorJobGroup.WAY_SECTIONED_PBF.getDescription(),
                     countryShardString, start.elapsedSince().asMilliseconds());
             // Report on memory usage
-            logger.info(MEMORY_MESSAGE, AtlasGeneratorJobGroup.WAY_SECTIONED.getDescription(),
+            logger.info(MEMORY_MESSAGE, AtlasGeneratorJobGroup.WAY_SECTIONED_PBF.getDescription(),
                     countryShardString);
             Memory.printCurrentMemory();
 

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
@@ -40,12 +40,6 @@ public enum AtlasGeneratorJobGroup
             "edgeOnlySubAtlas",
             Atlas.class,
             MultipleAtlasOutputFormat.class),
-    WAY_SECTIONED(
-            5,
-            "Way Sectioned Atlas Creation",
-            "atlas",
-            Atlas.class,
-            MultipleAtlasOutputFormat.class),
     WAY_SECTIONED_PBF(
             5,
             "Way Sectioned Atlas Creation",

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.openstreetmap.atlas.generator.persistence.AbstractMultipleAtlasBasedOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.generator.tools.spark.persistence.PersistenceTools;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.streaming.resource.Resource;
@@ -24,8 +25,6 @@ import org.openstreetmap.atlas.utilities.runtime.CommandMap;
  */
 public final class AtlasGeneratorParameters
 {
-    private static final String SHARDING_DEFAULT = "slippy@10";
-
     public static final Switch<StringList> COUNTRIES = new Switch<>("countries",
             "Comma separated list of countries to be included in the final Atlas",
             value -> StringList.split(value, ","), Optionality.REQUIRED);
@@ -46,9 +45,6 @@ public final class AtlasGeneratorParameters
                     + " (everything under the same folder)",
             SlippyTilePersistenceScheme::getSchemeInstanceFromString, Optionality.OPTIONAL,
             AbstractMultipleAtlasBasedOutputFormat.DEFAULT_SCHEME);
-    public static final Switch<String> SHARDING_TYPE = new Switch<>("sharding",
-            "The sharding definition.", StringConverter.IDENTITY, Optionality.OPTIONAL,
-            SHARDING_DEFAULT);
     public static final Switch<String> PREVIOUS_OUTPUT_FOR_DELTA = new Switch<>(
             "previousOutputForDelta",
             "The path of the output of the previous job that can be used for delta computation",
@@ -64,7 +60,6 @@ public final class AtlasGeneratorParameters
             "waySectioningConfiguration",
             "The path to the configuration file that defines where to section Ways to make Edges.",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
-
     public static final Switch<String> SLICING_CONFIGURATION = new Switch<>("slicingConfiguration",
             "The path to the configuration file that defines which relations to dynamically expand when slicing.",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
@@ -86,7 +81,6 @@ public final class AtlasGeneratorParameters
                     + " always be attempted regardless of the number of countries it intersects according to the"
                     + " country boundary map's grid index.",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
-
     public static final Switch<String> SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION = new Switch<>(
             "shouldIncludeFilteredOutputConfiguration",
             "The path to the configuration file that defines which will be included in filtered output."
@@ -100,6 +94,10 @@ public final class AtlasGeneratorParameters
             "lineDelimitedGeojsonOutput",
             "Output each shard as a line delimited geojson outout file in the ldgeojson folder.",
             Boolean::parseBoolean, Optionality.OPTIONAL, "false");
+    private static final String SHARDING_DEFAULT = "slippy@10";
+    public static final Switch<String> SHARDING_TYPE = new Switch<>("sharding",
+            "The sharding definition.", StringConverter.IDENTITY, Optionality.OPTIONAL,
+            SHARDING_DEFAULT);
 
     public static StandardConfiguration getStandardConfigurationFrom(
             final Resource configurationResource)
@@ -211,7 +209,8 @@ public final class AtlasGeneratorParameters
                 EDGE_CONFIGURATION, WAY_SECTIONING_CONFIGURATION, PBF_NODE_CONFIGURATION,
                 PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, SLICING_CONFIGURATION,
                 ATLAS_SCHEME, SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT,
-                LINE_DELIMITED_GEOJSON_OUTPUT, SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION);
+                LINE_DELIMITED_GEOJSON_OUTPUT, SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION,
+                PersistenceTools.COPY_SHARDING_AND_BOUNDARIES);
     }
 
     private AtlasGeneratorParameters()

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -29,7 +29,7 @@ public final class AtlasGeneratorParameters
             "Comma separated list of countries to be included in the final Atlas",
             value -> StringList.split(value, ","), Optionality.REQUIRED);
     public static final Switch<String> COUNTRY_SHAPES = new Switch<>("countryShapes",
-            "Shape file containing the countries", StringConverter.IDENTITY, Optionality.REQUIRED);
+            "Shape file containing the countries", StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<String> PBF_PATH = new Switch<>("pbfs", "The path to PBFs",
             StringConverter.IDENTITY, Optionality.REQUIRED);
     public static final Switch<SlippyTilePersistenceScheme> PBF_SCHEME = new Switch<>("pbfScheme",
@@ -87,17 +87,12 @@ public final class AtlasGeneratorParameters
                     + " Filtered output will only be generated if this switch is specificed, and will be"
                     + " stored in a separate subdirectory.",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
-    public static final Switch<Boolean> USE_JAVA_FORMAT = new Switch<>("useJavaFormat",
-            "Generate the atlas files using the java serialization atlas format (as opposed to the protobuf format).",
-            Boolean::parseBoolean, Optionality.OPTIONAL, "false");
     public static final Switch<Boolean> LINE_DELIMITED_GEOJSON_OUTPUT = new Switch<>(
             "lineDelimitedGeojsonOutput",
-            "Output each shard as a line delimited geojson outout file in the ldgeojson folder.",
+            "Output each shard as a line delimited geojson output file in the ldgeojson folder.",
             Boolean::parseBoolean, Optionality.OPTIONAL, "false");
-    private static final String SHARDING_DEFAULT = "slippy@10";
     public static final Switch<String> SHARDING_TYPE = new Switch<>("sharding",
-            "The sharding definition.", StringConverter.IDENTITY, Optionality.OPTIONAL,
-            SHARDING_DEFAULT);
+            "The sharding definition.", StringConverter.IDENTITY, Optionality.OPTIONAL);
 
     public static StandardConfiguration getStandardConfigurationFrom(
             final Resource configurationResource)
@@ -208,8 +203,8 @@ public final class AtlasGeneratorParameters
                 PBF_SHARDING, PREVIOUS_OUTPUT_FOR_DELTA, CODE_VERSION, DATA_VERSION,
                 EDGE_CONFIGURATION, WAY_SECTIONING_CONFIGURATION, PBF_NODE_CONFIGURATION,
                 PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, SLICING_CONFIGURATION,
-                ATLAS_SCHEME, SHOULD_ALWAYS_SLICE_CONFIGURATION, USE_JAVA_FORMAT,
-                LINE_DELIMITED_GEOJSON_OUTPUT, SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION,
+                ATLAS_SCHEME, SHOULD_ALWAYS_SLICE_CONFIGURATION, LINE_DELIMITED_GEOJSON_OUTPUT,
+                SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION,
                 PersistenceTools.COPY_SHARDING_AND_BOUNDARIES);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
@@ -47,9 +47,6 @@ import scala.Tuple2;
  */
 public abstract class SparkJob extends Command implements Serializable
 {
-    private static final long serialVersionUID = -3267868312907886517L;
-    private static final Logger logger = LoggerFactory.getLogger(SparkJob.class);
-
     public static final Switch<String> INPUT = new Switch<>("input", "Input path of the Spark Job",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<String> OUTPUT = new Switch<>("output",
@@ -74,6 +71,9 @@ public abstract class SparkJob extends Command implements Serializable
     public static final String SUCCESS_FILE = "_SUCCESS";
     public static final String FAILED_FILE = "_FAILED";
     public static final String SAVING_SEPARATOR = "-";
+
+    private static final long serialVersionUID = -3267868312907886517L;
+    private static final Logger logger = LoggerFactory.getLogger(SparkJob.class);
 
     private transient JavaSparkContext context;
 

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
@@ -151,7 +151,9 @@ public abstract class SparkJob extends Command implements Serializable
             options.forEach(hadoopConfiguration::set);
 
             FileSystemPerformanceHelper.openRenamePool();
+            runBefore(command);
             start(command);
+            runAfter(command);
             FileSystemPerformanceHelper.waitForAndCloseRenamePool();
             writeStatus(output, SUCCESS_FILE, "Success!");
         }
@@ -160,7 +162,16 @@ public abstract class SparkJob extends Command implements Serializable
             writeStatus(output, FAILED_FILE, "Failed!");
             throw new CoreException("Job {} failed.", getName(), e);
         }
+
         return 0;
+    }
+
+    public void runAfter(final CommandMap command)
+    {
+    }
+
+    public void runBefore(final CommandMap command)
+    {
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/converters/ConfigurationConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/converters/ConfigurationConverter.java
@@ -19,17 +19,6 @@ public final class ConfigurationConverter
         return result;
     }
 
-    public static Configuration hadoopToSparkConfiguration(final SparkConf sparkConfiguration)
-    {
-        final Configuration result = new Configuration();
-        final Tuple2<String, String>[] all = sparkConfiguration.getAll();
-        for (final Tuple2<String, String> tuple : all)
-        {
-            result.set(tuple._1(), tuple._2());
-        }
-        return result;
-    }
-
     public static Configuration mapToHadoopConfiguration(final Map<String, String> map)
     {
         final Configuration result = new Configuration();
@@ -41,6 +30,17 @@ public final class ConfigurationConverter
     {
         final SparkConf result = new SparkConf();
         map.forEach(result::set);
+        return result;
+    }
+
+    public static Configuration sparkToHadoopConfiguration(final SparkConf sparkConfiguration)
+    {
+        final Configuration result = new Configuration();
+        final Tuple2<String, String>[] all = sparkConfiguration.getAll();
+        for (final Tuple2<String, String> tuple : all)
+        {
+            result.set(tuple._1(), tuple._2());
+        }
         return result;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/converters/ConfigurationConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/converters/ConfigurationConverter.java
@@ -3,15 +3,43 @@ package org.openstreetmap.atlas.generator.tools.spark.converters;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+
+import scala.Tuple2;
 
 /**
  * @author matthieun
  */
 public final class ConfigurationConverter
 {
+    public static SparkConf hadoopToSparkConfiguration(final Configuration hadoopConfiguration)
+    {
+        final SparkConf result = new SparkConf();
+        hadoopConfiguration.forEach(entry -> result.set(entry.getKey(), entry.getValue()));
+        return result;
+    }
+
+    public static Configuration hadoopToSparkConfiguration(final SparkConf sparkConfiguration)
+    {
+        final Configuration result = new Configuration();
+        final Tuple2<String, String>[] all = sparkConfiguration.getAll();
+        for (final Tuple2<String, String> tuple : all)
+        {
+            result.set(tuple._1(), tuple._2());
+        }
+        return result;
+    }
+
     public static Configuration mapToHadoopConfiguration(final Map<String, String> map)
     {
         final Configuration result = new Configuration();
+        map.forEach(result::set);
+        return result;
+    }
+
+    public static SparkConf mapToSparkConfiguration(final Map<String, String> map)
+    {
+        final SparkConf result = new SparkConf();
         map.forEach(result::set);
         return result;
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/converters/ConfigurationConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/converters/ConfigurationConverter.java
@@ -1,0 +1,22 @@
+package org.openstreetmap.atlas.generator.tools.spark.converters;
+
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * @author matthieun
+ */
+public final class ConfigurationConverter
+{
+    public static Configuration mapToHadoopConfiguration(final Map<String, String> map)
+    {
+        final Configuration result = new Configuration();
+        map.forEach(result::set);
+        return result;
+    }
+
+    private ConfigurationConverter()
+    {
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
@@ -1,0 +1,97 @@
+package org.openstreetmap.atlas.generator.tools.spark.persistence;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
+import org.openstreetmap.atlas.generator.tools.spark.converters.ConfigurationConverter;
+import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
+import org.openstreetmap.atlas.geography.sharding.Sharding;
+import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
+import org.openstreetmap.atlas.utilities.runtime.Command.Optionality;
+import org.openstreetmap.atlas.utilities.runtime.Command.Switch;
+
+/**
+ * @author matthieun
+ */
+public final class PersistenceTools
+{
+    public static final String SHARDING_FILE = "sharding.txt";
+    public static final String BOUNDARIES_FILE = "boundaries.txt.gz";
+    public static final String SHARDING_META = "sharding.meta";
+    public static final String BOUNDARIES_META = "boundaries.meta";
+
+    public static final Switch<Boolean> COPY_SHARDING_AND_BOUNDARIES = new Switch<>(
+            "copyShardingAndBoundaries",
+            "Copy the sharding tree and boundary file used in this job, if any",
+            Boolean::parseBoolean, Optionality.OPTIONAL, "false");
+
+    private static final Integer BUFFER_SIZE = 4 * 1024;
+
+    public static CountryBoundaryMap boundaries(final String input,
+            final Map<String, String> configuration)
+    {
+        final Configuration hadoopConfiguration = ConfigurationConverter
+                .mapToHadoopConfiguration(configuration);
+        final Path inputPath = new Path(Paths.get(input, BOUNDARIES_FILE).toString());
+        return CountryBoundaryMap.fromPlainText(new InputStreamResource(() ->
+        {
+            try
+            {
+                return inputPath.getFileSystem(hadoopConfiguration).open(inputPath);
+            }
+            catch (final IOException e)
+            {
+                throw new CoreException("Unable to open {}", inputPath.toUri().toString(), e);
+            }
+        }));
+    }
+
+    public static void copyShardingAndBoundariesToOutput(final String input, final String output,
+            final Map<String, String> configuration)
+    {
+        final Configuration hadoopConfiguration = ConfigurationConverter
+                .mapToHadoopConfiguration(configuration);
+        copyToOutput(input, output, SHARDING_FILE, hadoopConfiguration);
+        copyToOutput(input, output, SHARDING_META, hadoopConfiguration);
+        copyToOutput(input, output, BOUNDARIES_FILE, hadoopConfiguration);
+        copyToOutput(input, output, BOUNDARIES_META, hadoopConfiguration);
+    }
+
+    public static Sharding sharding(final String input, final Map<String, String> configuration)
+    {
+        final Configuration hadoopConfiguration = ConfigurationConverter
+                .mapToHadoopConfiguration(configuration);
+        final Path inputPath = new Path(Paths.get(input, SHARDING_FILE).toString());
+        return AtlasSharding.forString("dynamic@" + inputPath.toUri().toString(),
+                hadoopConfiguration);
+    }
+
+    private static void copyToOutput(final String input, final String output, final String name,
+            final Configuration configuration)
+    {
+        final Path inputPath = new Path(Paths.get(input, name).toString());
+        final Path outputPath = new Path(Paths.get(output, name).toString());
+        try (InputStream inputStream = inputPath.getFileSystem(configuration).open(inputPath);
+                OutputStream outputStream = outputPath.getFileSystem(configuration)
+                        .create(outputPath))
+        {
+            IOUtils.copyBytes(inputStream, outputStream, BUFFER_SIZE, true);
+        }
+        catch (final IOException e)
+        {
+            throw new CoreException("Unable to copy {} to {}", input, output, e);
+        }
+    }
+
+    private PersistenceTools()
+    {
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
@@ -43,7 +43,7 @@ public class PersistenceTools
     public CountryBoundaryMap boundaries(final String input)
     {
         final Configuration hadoopConfiguration = hadoopConfiguration();
-        final Path inputPath = new Path(strip(input) + BOUNDARIES_FILE);
+        final Path inputPath = new Path(appendDirectorySeparator(input) + BOUNDARIES_FILE);
         return CountryBoundaryMap.fromPlainText(new InputStreamResource(() ->
         {
             try
@@ -68,12 +68,12 @@ public class PersistenceTools
     public Sharding sharding(final String input)
     {
         final Configuration hadoopConfiguration = hadoopConfiguration();
-        final Path inputPath = new Path(strip(input) + SHARDING_FILE);
+        final Path inputPath = new Path(appendDirectorySeparator(input) + SHARDING_FILE);
         return AtlasSharding.forString("dynamic@" + inputPath.toUri().toString(),
                 hadoopConfiguration);
     }
 
-    final String strip(final String input)
+    private String appendDirectorySeparator(final String input)
     {
         final String inputString;
         if (input.endsWith("/"))
@@ -89,8 +89,8 @@ public class PersistenceTools
 
     private void copyToOutput(final String input, final String output, final String name)
     {
-        final Path inputPath = new Path(strip(input) + name);
-        final Path outputPath = new Path(strip(output) + name);
+        final Path inputPath = new Path(appendDirectorySeparator(input) + name);
+        final Path outputPath = new Path(appendDirectorySeparator(output) + name);
         final Configuration configuration = hadoopConfiguration();
         try (InputStream inputStream = inputPath.getFileSystem(configuration).open(inputPath);
                 OutputStream outputStream = outputPath.getFileSystem(configuration)

--- a/src/test/java/org/openstreetmap/atlas/generator/AtlasGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/AtlasGeneratorTest.java
@@ -11,7 +11,8 @@ import org.openstreetmap.atlas.geography.sharding.DynamicTileSharding;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
-import org.openstreetmap.atlas.utilities.collections.StringList;
+
+import com.google.common.collect.Lists;
 
 /**
  * Tests for {@link AtlasGenerator}.
@@ -32,47 +33,48 @@ public class AtlasGeneratorTest
     public void testGenerateTasksEmptyBoundary()
     {
         final CountryBoundaryMap boundaryMap = new CountryBoundaryMap();
-        Assert.assertTrue(AtlasGenerator.generateTasks(new StringList("HTI"), boundaryMap, SHARDING)
-                .isEmpty());
+        Assert.assertTrue(AtlasGenerator
+                .generateTasks(Lists.newArrayList("HTI"), boundaryMap, SHARDING).isEmpty());
     }
 
     @Test
     public void testGenerateTasksEmptyBoundaryAndCountryList()
     {
         final CountryBoundaryMap boundaryMap = new CountryBoundaryMap();
-        Assert.assertTrue(
-                AtlasGenerator.generateTasks(new StringList(), boundaryMap, SHARDING).isEmpty());
+        Assert.assertTrue(AtlasGenerator.generateTasks(Lists.newArrayList(), boundaryMap, SHARDING)
+                .isEmpty());
     }
 
     @Test
     public void testGenerateTasksEmptyCountryList()
     {
-        Assert.assertTrue(AtlasGenerator.generateTasks(new StringList(), HTI_BOUNDARY_MAP, SHARDING)
-                .isEmpty());
+        Assert.assertTrue(AtlasGenerator
+                .generateTasks(Lists.newArrayList(), HTI_BOUNDARY_MAP, SHARDING).isEmpty());
     }
 
     @Test
     public void testGenerateTasksHTI()
     {
         // HTI boundary should have generated 36 tasks
-        testCountry(new StringList("HTI"), HTI_BOUNDARY_MAP, 36);
+        testCountry(Lists.newArrayList("HTI"), HTI_BOUNDARY_MAP, 36);
     }
 
     @Test
     public void testGenerateTasksJAM()
     {
         // JAM boundary should have generated 6 tasks
-        testCountry(new StringList("JAM"), JAM_BOUNDARY_MAP, 6);
+        testCountry(Lists.newArrayList("JAM"), JAM_BOUNDARY_MAP, 6);
     }
 
     @Test
     public void testGenerateTasksWrongCountryList()
     {
         Assert.assertTrue(AtlasGenerator
-                .generateTasks(new StringList("ABC", "XYZ"), JAM_BOUNDARY_MAP, SHARDING).isEmpty());
+                .generateTasks(Lists.newArrayList("ABC", "XYZ"), JAM_BOUNDARY_MAP, SHARDING)
+                .isEmpty());
     }
 
-    private void testCountry(final StringList countries, final CountryBoundaryMap boundaryMap,
+    private void testCountry(final List<String> countries, final CountryBoundaryMap boundaryMap,
             final int expectedTaskSize)
     {
         final List<AtlasGenerationTask> tasks = AtlasGenerator.generateTasks(countries, boundaryMap,


### PR DESCRIPTION
### Description:

This allows the `AtlasGenerator` job to save the Sharding tree and Boundary file to the output folder. If present in the input PBF folder, it also uses those sharding and boundary files in priority, rather than the ones supplied in the parameters.

### Potential Impact:

This should be transparent to existing toolchains, as the existing parameters are still valid.

### Unit Test Approach:

Updated `AtlasGeneratorIntegrationTest`

### Test Results:

Tests pass. Also the `./gradlew run` command still works as expected.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)