### PR TITLE
Checkstyle RequireThis changed and update was missed

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -111,6 +111,7 @@
 		<module name="ParameterAssignment"/>
 		<module name="RequireThis">
     		<property name="checkMethods" value="false"/>
+			<property name="validateOnlyOverlapping" value="false"/>
 		</module>
 		<module name="SimplifyBooleanExpression" />
 		<module name="SimplifyBooleanReturn" />

--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/tools/spark/rdd/SparkRDDTestBase.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/tools/spark/rdd/SparkRDDTestBase.java
@@ -25,44 +25,44 @@ public class SparkRDDTestBase extends DefaultSparkContextProvider
     @Before
     public void initialize()
     {
-        if (sparkContext == null)
+        if (this.sparkContext == null)
         {
-            sparkContext = new DefaultSparkContextProvider().apply(getConfiguration());
+            this.sparkContext = new DefaultSparkContextProvider().apply(getConfiguration());
         }
     }
 
     @After
     public void stopContext()
     {
-        if (sparkContext != null)
+        if (this.sparkContext != null)
         {
-            sparkContext.stop();
+            this.sparkContext.stop();
         }
-    }
-
-    protected JavaSparkContext getSparkContext()
-    {
-        return sparkContext;
-    }
-
-    protected Map<String, String> getFileSystemConfiguration()
-    {
-        return fileSystemConfig;
-    }
-
-    protected void setFileSystemConfiguration(final Map<String, String> fileSystemConfiguration)
-    {
-        this.fileSystemConfig = fileSystemConfiguration;
     }
 
     protected SparkConf getConfiguration()
     {
-        return configuration;
+        return this.configuration;
+    }
+
+    protected Map<String, String> getFileSystemConfiguration()
+    {
+        return this.fileSystemConfig;
+    }
+
+    protected JavaSparkContext getSparkContext()
+    {
+        return this.sparkContext;
     }
 
     protected void setConfiguration(final SparkConf configuration)
     {
         this.configuration = configuration;
+    }
+
+    protected void setFileSystemConfiguration(final Map<String, String> fileSystemConfiguration)
+    {
+        this.fileSystemConfig = fileSystemConfiguration;
     }
 
 }


### PR DESCRIPTION
### Description:

The `RequireThis` plugin in Checkstyle was updated after `6.17`, and this update was missed.

Adding
```xml
<property name="validateOnlyOverlapping" value="false"/>
``` 
enforces the same behavior as before.

Thanks @Huyuntj for finding out!

- Fixes all the violations that sneaked in in the mean time.
- Updates code ordering when it was not alphabetical

### Potential Impact:

No impact, code style and readability only.

### Unit Test Approach:

Use same tests

### Test Results:

Tests pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)