### PR TITLE
Proper centralization of resource accession

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -8,7 +8,9 @@ import org.junit.Test;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.tools.spark.persistence.PersistenceTools;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
+import org.openstreetmap.atlas.streaming.compression.Compressor;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
+import org.openstreetmap.atlas.streaming.resource.ByteArrayResource;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.streaming.resource.Resource;
@@ -38,15 +40,28 @@ public class AtlasGeneratorIntegrationTest
         addResource(PBF_233, "DMA_cutout.osm.pbf");
         addResource(PBF_234, "DMA_cutout.osm.pbf");
         addResource(INPUT_SHARDING, "tree-6-14-100000.txt");
-        addResource(INPUT_BOUNDARIES, "DMA.txt");
+        addResource(INPUT_BOUNDARIES, "DMA.txt", true);
         addResourceContents(INPUT_BOUNDARIES_META, "Meta data for boundaries");
         addResourceContents(INPUT_SHARDING_META, "Meta data for sharding");
     }
 
+    public static void addResource(final String path, final String name, final boolean gzipIt)
+    {
+        Resource input = new InputStreamResource(
+                () -> AtlasGeneratorIntegrationTest.class.getResourceAsStream(name));
+        if (gzipIt)
+        {
+            final ByteArrayResource newInput = new ByteArrayResource();
+            newInput.setCompressor(Compressor.GZIP);
+            input.copyTo(newInput);
+            input = newInput;
+        }
+        ResourceFileSystem.addResource(path, input);
+    }
+
     private static void addResource(final String path, final String name)
     {
-        ResourceFileSystem.addResource(path, new InputStreamResource(
-                () -> AtlasGeneratorIntegrationTest.class.getResourceAsStream(name)));
+        addResource(path, name, false);
     }
 
     private static void addResourceContents(final String path, final String contents)

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/converters/ConfigurationConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/converters/ConfigurationConverter.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.generator.tools.spark.converters;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
@@ -12,6 +13,14 @@ import scala.Tuple2;
  */
 public final class ConfigurationConverter
 {
+    public static Map<String, String> hadoopToMapConfiguration(
+            final Configuration hadoopConfiguration)
+    {
+        final Map<String, String> result = new HashMap<>();
+        hadoopConfiguration.forEach(entry -> result.put(entry.getKey(), entry.getValue()));
+        return result;
+    }
+
     public static SparkConf hadoopToSparkConfiguration(final Configuration hadoopConfiguration)
     {
         final SparkConf result = new SparkConf();

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
@@ -10,10 +10,10 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
+import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
 import org.openstreetmap.atlas.generator.tools.spark.converters.ConfigurationConverter;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
-import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.utilities.runtime.Command.Optionality;
 import org.openstreetmap.atlas.utilities.runtime.Command.Switch;
 
@@ -42,19 +42,8 @@ public class PersistenceTools
 
     public CountryBoundaryMap boundaries(final String input)
     {
-        final Configuration hadoopConfiguration = hadoopConfiguration();
-        final Path inputPath = new Path(appendDirectorySeparator(input) + BOUNDARIES_FILE);
-        return CountryBoundaryMap.fromPlainText(new InputStreamResource(() ->
-        {
-            try
-            {
-                return inputPath.getFileSystem(hadoopConfiguration).open(inputPath);
-            }
-            catch (final IOException e)
-            {
-                throw new CoreException("Unable to open {}", inputPath.toUri().toString(), e);
-            }
-        }));
+        return CountryBoundaryMap.fromPlainText(SparkJob.resource(
+                appendDirectorySeparator(input) + BOUNDARIES_FILE, this.configurationMap));
     }
 
     public void copyShardingAndBoundariesToOutput(final String input, final String output)


### PR DESCRIPTION
### Description:

This fixes the access of boundary files using `PersistenceTools` which was failing to read gzipped files properly.

### Potential Impact:

The copying of resources is unchanged, however the boundary deserialization now works.

### Unit Test Approach:

Using same unit tests

### Test Results:

Same

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
