### PR TITLE
Added configured filter output option to Atlas Generation

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -34,6 +34,8 @@ public class AtlasGeneratorIntegrationTest
     public static final String ATLAS_OUTPUT = "resource://test/atlas";
     public static final String LINE_DELIMITED_GEOJSON_OUTPUT = "resource://test/"
             + AtlasGenerator.LINE_DELIMITED_GEOJSON_STATISTICS_FOLDER + "/DMA";
+    public static final String CONFIGURED_OUTPUT_FILTER = "resource://test/filter/nothingFilter.json";
+    public static final String FILTER_NAME = "nothingFitler";
 
     static
     {
@@ -41,6 +43,7 @@ public class AtlasGeneratorIntegrationTest
         addResource(PBF_234, "DMA_cutout.osm.pbf");
         addResource(INPUT_SHARDING, "tree-6-14-100000.txt");
         addResource(INPUT_BOUNDARIES, "DMA.txt", true);
+        addResource(CONFIGURED_OUTPUT_FILTER, "nothingFilter.json");
         addResourceContents(INPUT_BOUNDARIES_META, "Meta data for boundaries");
         addResourceContents(INPUT_SHARDING_META, "Meta data for sharding");
     }
@@ -82,6 +85,8 @@ public class AtlasGeneratorIntegrationTest
         arguments.add("-atlasScheme=zz/");
         arguments.add("-lineDelimitedGeojsonOutput=true");
         arguments.add("-copyShardingAndBoundaries=true");
+        arguments.add("-configuredOutputFilter=" + CONFIGURED_OUTPUT_FILTER);
+        arguments.add("-configuredFilterName=" + FILTER_NAME);
         arguments.add(
                 "-sparkOptions=fs.resource.impl=" + ResourceFileSystem.class.getCanonicalName());
 
@@ -122,6 +127,11 @@ public class AtlasGeneratorIntegrationTest
                     .exists(new Path(ATLAS_OUTPUT + "/" + PersistenceTools.BOUNDARIES_FILE)));
             Assert.assertTrue(resourceFileSystem
                     .exists(new Path(ATLAS_OUTPUT + "/" + PersistenceTools.BOUNDARIES_META)));
+
+            Assert.assertTrue(resourceFileSystem.exists(
+                    new Path("resource://test/configuredOutput/DMA/9/DMA_9-168-233.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(
+                    new Path("resource://test/configuredOutput/DMA/9/DMA_9-168-234.atlas")));
         }
         catch (IllegalArgumentException | IOException e)
         {

--- a/src/integrationTest/resources/org/openstreetmap/atlas/generator/nothingFilter.json
+++ b/src/integrationTest/resources/org/openstreetmap/atlas/generator/nothingFilter.json
@@ -1,0 +1,16 @@
+{
+    "global":
+    {
+        "scanUrls": ["org.openstreetmap.atlas"],
+        "filters":
+        {
+            "nothingFilter":
+            {
+                "predicate":
+                {
+                    "command": "true"
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -564,7 +564,7 @@ public final class AtlasGeneratorHelper implements Serializable
     protected static PairFunction<Tuple2<String, Atlas>, String, Atlas> subatlas(
             final ConfiguredFilter filter, final AtlasCutType cutType)
     {
-        return tuple ->
+        return (Serializable & PairFunction<Tuple2<String, Atlas>, String, Atlas>) tuple ->
         {
             final Atlas subAtlas;
             // Grab the tuple contents
@@ -587,7 +587,7 @@ public final class AtlasGeneratorHelper implements Serializable
                     logger.error("Unable to extract valid subAtlas code for {}", shardName);
                 }
             }
-            catch (final Throwable e) // NOSONAR
+            catch (final Exception e) // NOSONAR
             {
                 throw new CoreException("Sub Atlas failed for {}", shardName, e);
             }
@@ -603,7 +603,7 @@ public final class AtlasGeneratorHelper implements Serializable
     protected static PairFunction<Tuple2<String, Atlas>, String, Atlas> subatlas(
             final Predicate<Taggable> filter, final AtlasCutType cutType)
     {
-        return tuple ->
+        return (Serializable & PairFunction<Tuple2<String, Atlas>, String, Atlas>) tuple ->
         {
             final Atlas subAtlas;
 
@@ -630,7 +630,7 @@ public final class AtlasGeneratorHelper implements Serializable
 
             }
 
-            catch (final Throwable e) // NOSONAR
+            catch (final Exception e) // NOSONAR
             {
                 throw new CoreException("Sub Atlas failed for {}", shardName, e);
             }

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
@@ -69,6 +69,12 @@ public enum AtlasGeneratorJobGroup
             "Taggable Filtered SubAtlas Creation",
             "filteredOutput",
             Atlas.class,
+            MultipleAtlasOutputFormat.class),
+    CONFIGURED_FILTERED_OUTPUT(
+            10,
+            "Configured Filtered SubAtlas Creation",
+            "configuredOutput",
+            Atlas.class,
             MultipleAtlasOutputFormat.class);
 
     private final String description;

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -13,6 +13,7 @@ import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.tags.filters.ConfiguredTaggableFilter;
 import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.configuration.ConfiguredFilter;
 import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
 import org.openstreetmap.atlas.utilities.conversion.StringConverter;
 import org.openstreetmap.atlas.utilities.runtime.Command.Optionality;
@@ -93,6 +94,18 @@ public final class AtlasGeneratorParameters
             Boolean::parseBoolean, Optionality.OPTIONAL, "false");
     public static final Switch<String> SHARDING_TYPE = new Switch<>("sharding",
             "The sharding definition.", StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<String> CONFIGURED_FILTER_OUTPUT = new Switch<>(
+            "configuredOutputFilter", "Path to configuration file for filtered output",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
+    public static final Switch<String> CONFIGURED_FILTER_NAME = new Switch<>("configuredFilterName",
+            "Name of the filter to be used for configured output", StringConverter.IDENTITY,
+            Optionality.OPTIONAL);
+
+    public static ConfiguredFilter getConfiguredFilterFrom(final String name,
+            final Resource configurationResource)
+    {
+        return ConfiguredFilter.from(name, getStandardConfigurationFrom(configurationResource));
+    }
 
     public static StandardConfiguration getStandardConfigurationFrom(
             final Resource configurationResource)
@@ -205,7 +218,8 @@ public final class AtlasGeneratorParameters
                 PBF_WAY_CONFIGURATION, PBF_RELATION_CONFIGURATION, SLICING_CONFIGURATION,
                 ATLAS_SCHEME, SHOULD_ALWAYS_SLICE_CONFIGURATION, LINE_DELIMITED_GEOJSON_OUTPUT,
                 SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION,
-                PersistenceTools.COPY_SHARDING_AND_BOUNDARIES);
+                PersistenceTools.COPY_SHARDING_AND_BOUNDARIES, CONFIGURED_FILTER_OUTPUT,
+                CONFIGURED_FILTER_NAME);
     }
 
     private AtlasGeneratorParameters()

--- a/src/main/java/org/openstreetmap/atlas/generator/world/AtlasFilePathFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/AtlasFilePathFilter.java
@@ -1,0 +1,19 @@
+package org.openstreetmap.atlas.generator.world;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
+
+/**
+ * Filter that only accepts .atlas files.
+ *
+ * @author jwpgage
+ */
+public class AtlasFilePathFilter implements PathFilter
+{
+    @Override
+    public boolean accept(final Path path)
+    {
+        return path.getName().endsWith(FileSuffix.ATLAS.toString());
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldMultiAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldMultiAtlasGenerator.java
@@ -23,9 +23,9 @@ import org.slf4j.LoggerFactory;
 public class WorldMultiAtlasGenerator extends Command
 {
     private static final Switch<String> ATLAS_PATH = new Switch<>("atlasPath",
-            "The path to the ferry atlas root directory", value -> value, Optionality.REQUIRED);
+            "The path to the atlas directory", value -> value, Optionality.REQUIRED);
     private static final Switch<String> OUTPUT_PATH = new Switch<>("outputPath",
-            "The path to the output world ferry atlas", value -> value, Optionality.REQUIRED);
+            "The path to the output world multi atlas", value -> value, Optionality.REQUIRED);
     private static final Logger logger = LoggerFactory.getLogger(WorldMultiAtlasGenerator.class);
 
     public static void main(final String[] args)

--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldMultiAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldMultiAtlasGenerator.java
@@ -1,0 +1,59 @@
+package org.openstreetmap.atlas.generator.world;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
+import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasCloner;
+import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.utilities.runtime.Command;
+import org.openstreetmap.atlas.utilities.runtime.CommandMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Command that multiatlases together all atlas shards within an input directory.
+ *
+ * @author jwpgage
+ */
+public class WorldMultiAtlasGenerator extends Command
+{
+    private static final Switch<String> ATLAS_PATH = new Switch<>("atlasPath",
+            "The path to the ferry atlas root directory", value -> value, Optionality.REQUIRED);
+    private static final Switch<String> OUTPUT_PATH = new Switch<>("outputPath",
+            "The path to the output world ferry atlas", value -> value, Optionality.REQUIRED);
+    private static final Logger logger = LoggerFactory.getLogger(WorldMultiAtlasGenerator.class);
+
+    public static void main(final String[] args)
+    {
+        new WorldMultiAtlasGenerator().run(args);
+    }
+
+    @Override
+    protected int onRun(final CommandMap command)
+    {
+        final String atlasPath = (String) command.get(ATLAS_PATH);
+        final String outputPath = (String) command.get(OUTPUT_PATH);
+        final Map<String, String> configuration = new HashMap<>();
+        configuration.put("fs.file.impl", "org.apache.hadoop.fs.LocalFileSystem");
+        final List<Resource> atlasFiles = FileSystemHelper.listResourcesRecursively(atlasPath,
+                configuration, new AtlasFilePathFilter());
+        logger.info("Creating multiatlas from input atlases.");
+        final MultiAtlas multiAtlas = MultiAtlas.loadFromPackedAtlas(atlasFiles);
+        final PackedAtlasCloner packedAtlasCloner = new PackedAtlasCloner();
+        final Atlas finalAtlas = packedAtlasCloner.cloneFrom(multiAtlas);
+        finalAtlas.save(new File(outputPath));
+        logger.info("Final atlas saved to " + outputPath);
+        return 0;
+    }
+
+    @Override
+    protected SwitchList switches()
+    {
+        return new SwitchList().with(ATLAS_PATH, OUTPUT_PATH);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldMultiAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldMultiAtlasGenerator.java
@@ -47,7 +47,7 @@ public class WorldMultiAtlasGenerator extends Command
         final PackedAtlasCloner packedAtlasCloner = new PackedAtlasCloner();
         final Atlas finalAtlas = packedAtlasCloner.cloneFrom(multiAtlas);
         finalAtlas.save(new File(outputPath));
-        logger.info("Final atlas saved to " + outputPath);
+        logger.info("Final atlas saved to {}", outputPath);
         return 0;
     }
 


### PR DESCRIPTION
### Description:

This PR adds an option to Altas generation for configured filter output. This output is optional, and allows for more complicated predicates to be used in filtering output than the `ConfiguredTaggableFilter`.

Also added in this PR is the `WorldMultiAtlasGenerator`, which is a command that takes an atlas directory and creates a corresponding multi atlas.

### Potential Impact:

Adds an option for configured filtered output to atlas generation.

### Unit Test Approach:

Tested atlas generation with and without the optional configured filter.

### Test Results:

Filtered output was as expected.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)