### PR TITLE
Reworked atlas fetcher to return Optional.empty() directly

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -138,7 +138,8 @@ public final class AtlasGeneratorHelper implements Serializable
                     atlasResources.add(cachedAtlas.get());
                 }
             });
-            return Optional.ofNullable(MultiAtlas.loadFromPackedAtlas(atlasResources));
+            return atlasResources.isEmpty() ? Optional.empty()
+                    : Optional.ofNullable(MultiAtlas.loadFromPackedAtlas(atlasResources));
         };
     }
 


### PR DESCRIPTION
### Description:
This PR just makes a small change to the atlas fetcher for multiple countries to force the returning of `Optional.empty()`directly in the case of no Atlases being found for any country.
### Potential Impact:
N/A
### Unit Test Approach:
N/A
### Test Results:
N/A
------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)