### PR TITLE
Validate downloaded atlas files in HadoopAtlasFileCache

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '8.18',
-    atlas: '5.7.8',
+    atlas: '5.7.9-SNAPSHOT',
     spark: '2.4.0-cdh6.2.0',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '8.18',
-    atlas: '5.7.9-SNAPSHOT',
+    atlas: '5.7.9',
     spark: '2.4.0-cdh6.2.0',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',


### PR DESCRIPTION
### Description:

This depends on https://github.com/osmlab/atlas/pull/536

Once an Atlas file is downloaded by `HadoopAtlasFileCache`, make sure it is not corrupt.

### Potential Impact:

This will throw an exception if the file is corrupt and it cannot open it. Since these are files at this point, it will not try to load the whole Atlas, but only the meta-data, which should be pretty lightweight.

### Unit Test Approach:

Use existing tests

### Test Results:

Use existing tests

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)