### PR TITLE
AtlasShardVerifier now uses getName instead of toString

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
@@ -44,7 +44,7 @@ public class AtlasShardVerifier extends Command
         expectedShards.removeAll(existingShards);
         try (SafeBufferedWriter writer = output.writer())
         {
-            expectedShards.stream().map(CountryShard::toString).forEach(writer::writeLine);
+            expectedShards.stream().map(CountryShard::getName).forEach(writer::writeLine);
         }
         catch (final Exception e)
         {


### PR DESCRIPTION
### Description:
Now that the `Shard#getName` method has been standardized, any code attempting to write a parsable shard string should be using this method.

See: https://github.com/osmlab/atlas/pull/541

### Potential Impact:
Parsing code expecting `toString` to give parsable output may be broken. This fixes that issue.

### Unit Test Approach:
N/A

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)