### PR TITLE
Allow for http-based configuration resources

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -17,7 +17,6 @@ import org.openstreetmap.atlas.generator.AtlasGeneratorHelper.NamedAtlasStatisti
 import org.openstreetmap.atlas.generator.persistence.MultipleLineDelimitedGeojsonOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
-import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
 import org.openstreetmap.atlas.generator.tools.spark.persistence.PersistenceTools;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
@@ -134,8 +133,8 @@ public class AtlasGenerator extends SparkJob
         }
         else
         {
-            taggableOutputFilter = AtlasGeneratorParameters.getTaggableFilterFrom(FileSystemHelper
-                    .resource(shouldIncludeFilteredOutputConfiguration, sparkContext));
+            taggableOutputFilter = AtlasGeneratorParameters
+                    .getTaggableFilterFrom(shouldIncludeFilteredOutputConfiguration, sparkContext);
         }
         if (configuredFilterPath != null)
         {
@@ -145,8 +144,7 @@ public class AtlasGenerator extends SparkJob
                         "A filter name must be provided for configured filter output!");
             }
             configuredOutputFilter = AtlasGeneratorParameters.getConfiguredFilterFrom(
-                    configuredFilterName,
-                    FileSystemHelper.resource(configuredFilterPath, sparkContext));
+                    configuredFilterName, configuredFilterPath, sparkContext);
         }
 
         final String output = output(command);

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import org.openstreetmap.atlas.generator.persistence.AbstractMultipleAtlasBasedOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
-import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
 import org.openstreetmap.atlas.generator.tools.spark.persistence.PersistenceTools;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
@@ -210,30 +209,30 @@ public final class AtlasGeneratorParameters
 
         final String edgeConfiguration = (String) command.get(EDGE_CONFIGURATION);
         propertyMap.put(EDGE_CONFIGURATION.getName(), edgeConfiguration == null ? null
-                : FileSystemHelper.resource(edgeConfiguration, sparkContext).all());
+                : pathToResource(edgeConfiguration, sparkContext).all());
 
         final String waySectioningConfiguration = (String) command
                 .get(WAY_SECTIONING_CONFIGURATION);
-        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null
-                ? null
-                : FileSystemHelper.resource(waySectioningConfiguration, sparkContext).all());
+        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(),
+                waySectioningConfiguration == null ? null
+                        : pathToResource(waySectioningConfiguration, sparkContext).all());
 
         final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
         propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
-                : FileSystemHelper.resource(pbfNodeConfiguration, sparkContext).all());
+                : pathToResource(pbfNodeConfiguration, sparkContext).all());
 
         final String pbfWayConfiguration = (String) command.get(PBF_WAY_CONFIGURATION);
         propertyMap.put(PBF_WAY_CONFIGURATION.getName(), pbfWayConfiguration == null ? null
-                : FileSystemHelper.resource(pbfWayConfiguration, sparkContext).all());
+                : pathToResource(pbfWayConfiguration, sparkContext).all());
 
         final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
         propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
                 pbfRelationConfiguration == null ? null
-                        : FileSystemHelper.resource(pbfRelationConfiguration, sparkContext).all());
+                        : pathToResource(pbfRelationConfiguration, sparkContext).all());
 
         final String slicingConfiguration = (String) command.get(SLICING_CONFIGURATION);
         propertyMap.put(SLICING_CONFIGURATION.getName(), slicingConfiguration == null ? null
-                : FileSystemHelper.resource(slicingConfiguration, sparkContext).all());
+                : pathToResource(slicingConfiguration, sparkContext).all());
 
         return propertyMap;
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -109,16 +109,34 @@ public final class AtlasGeneratorParameters
         return getConfiguredFilterFrom(name, pathToResource(path, configurationMap));
     }
 
+    public static ConfiguredFilter getConfiguredFilterFrom(final String name,
+            final Resource configurationResource)
+    {
+        return ConfiguredFilter.from(name, getStandardConfigurationFrom(configurationResource));
+    }
+
     public static StandardConfiguration getStandardConfigurationFrom(final String path,
             final Map<String, String> configurationMap)
     {
         return getStandardConfigurationFrom(pathToResource(path, configurationMap));
     }
 
+    public static StandardConfiguration getStandardConfigurationFrom(
+            final Resource configurationResource)
+    {
+        return new StandardConfiguration(configurationResource);
+    }
+
     public static ConfiguredTaggableFilter getTaggableFilterFrom(final String path,
             final Map<String, String> configurationMap)
     {
         return getTaggableFilterFrom(pathToResource(path, configurationMap));
+    }
+
+    public static ConfiguredTaggableFilter getTaggableFilterFrom(
+            final Resource configurationResource)
+    {
+        return new ConfiguredTaggableFilter(getStandardConfigurationFrom(configurationResource));
     }
 
     protected static AtlasLoadingOption buildAtlasLoadingOption(final CountryBoundaryMap boundaries,
@@ -230,24 +248,6 @@ public final class AtlasGeneratorParameters
                 SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION,
                 PersistenceTools.COPY_SHARDING_AND_BOUNDARIES, CONFIGURED_FILTER_OUTPUT,
                 CONFIGURED_FILTER_NAME);
-    }
-
-    private static ConfiguredFilter getConfiguredFilterFrom(final String name,
-            final Resource configurationResource)
-    {
-        return ConfiguredFilter.from(name, getStandardConfigurationFrom(configurationResource));
-    }
-
-    private static StandardConfiguration getStandardConfigurationFrom(
-            final Resource configurationResource)
-    {
-        return new StandardConfiguration(configurationResource);
-    }
-
-    private static ConfiguredTaggableFilter getTaggableFilterFrom(
-            final Resource configurationResource)
-    {
-        return new ConfiguredTaggableFilter(getStandardConfigurationFrom(configurationResource));
     }
 
     private static Resource pathToResource(final String path,


### PR DESCRIPTION
### Description:

Let AtlasGenerator pull its configuration from http-based resources.

### Potential Impact:

This is still backwards compatible, in which it still accepts file-system based resources.

### Unit Test Approach:

TBD

### Test Results:

TBD

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
