### PR TITLE
Output Format for FeatureChange lists

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -10,14 +10,11 @@ import org.openstreetmap.atlas.generator.tools.spark.persistence.PersistenceTool
 import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
-import org.openstreetmap.atlas.streaming.compression.Compressor;
 import org.openstreetmap.atlas.streaming.compression.Decompressor;
-import org.openstreetmap.atlas.streaming.resource.ByteArrayResource;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.streaming.resource.Resource;
-import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 
@@ -54,53 +51,28 @@ public class AtlasGeneratorIntegrationTest
 
     static
     {
-        addResource(PBF_233, "DMA_cutout.osm.pbf");
-        addResource(PBF_234, "DMA_cutout.osm.pbf");
-        addResource(INPUT_SHARDING, "tree-6-14-100000.txt");
-        addResource(INPUT_BOUNDARIES, "DMA.txt", true);
-        addResource(CONFIGURED_OUTPUT_FILTER, "nothingFilter.json");
-        addResourceContents(INPUT_BOUNDARIES_META, "Meta data for boundaries");
-        addResourceContents(INPUT_SHARDING_META, "Meta data for sharding");
-        addResource(EDGE_CONFIGURATION, "atlas-edge.json", false, AtlasLoadingOption.class);
-        addResource(WAY_SECTIONING_CONFIGURATION, "atlas-way-section.json", false,
+        ResourceFileSystem.registerResourceExtractionClass(AtlasGeneratorIntegrationTest.class);
+        ResourceFileSystem.addResource(PBF_233, "DMA_cutout.osm.pbf");
+        ResourceFileSystem.addResource(PBF_234, "DMA_cutout.osm.pbf");
+        ResourceFileSystem.addResource(INPUT_SHARDING, "tree-6-14-100000.txt");
+        ResourceFileSystem.addResource(INPUT_BOUNDARIES, "DMA.txt", true);
+        ResourceFileSystem.addResource(CONFIGURED_OUTPUT_FILTER, "nothingFilter.json");
+        ResourceFileSystem.addResourceContents(INPUT_BOUNDARIES_META, "Meta data for boundaries");
+        ResourceFileSystem.addResourceContents(INPUT_SHARDING_META, "Meta data for sharding");
+        ResourceFileSystem.addResource(EDGE_CONFIGURATION, "atlas-edge.json", false,
                 AtlasLoadingOption.class);
-        addResource(PBF_NODE_CONFIGURATION, "osm-pbf-node.json", false, AtlasLoadingOption.class);
-        addResource(PBF_WAY_CONFIGURATION, "osm-pbf-way.json", false, AtlasLoadingOption.class);
-        addResource(PBF_RELATION_CONFIGURATION, "osm-pbf-relation.json", false,
+        ResourceFileSystem.addResource(WAY_SECTIONING_CONFIGURATION, "atlas-way-section.json",
+                false, AtlasLoadingOption.class);
+        ResourceFileSystem.addResource(PBF_NODE_CONFIGURATION, "osm-pbf-node.json", false,
                 AtlasLoadingOption.class);
-        addResource(SHOULD_ALWAYS_SLICE_CONFIGURATION, "osm-pbf-relation.json", false,
+        ResourceFileSystem.addResource(PBF_WAY_CONFIGURATION, "osm-pbf-way.json", false,
                 AtlasLoadingOption.class);
-        addResource(SLICING_CONFIGURATION, "atlas-relation-slicing.json", false,
+        ResourceFileSystem.addResource(PBF_RELATION_CONFIGURATION, "osm-pbf-relation.json", false,
                 AtlasLoadingOption.class);
-    }
-
-    public static void addResource(final String path, final String name, final boolean gzipIt)
-    {
-        addResource(path, name, gzipIt, AtlasGeneratorIntegrationTest.class);
-    }
-
-    public static void addResource(final String path, final String name, final boolean gzipIt,
-            final Class<?> clazz)
-    {
-        Resource input = new InputStreamResource(() -> clazz.getResourceAsStream(name));
-        if (gzipIt)
-        {
-            final ByteArrayResource newInput = new ByteArrayResource();
-            newInput.setCompressor(Compressor.GZIP);
-            input.copyTo(newInput);
-            input = newInput;
-        }
-        ResourceFileSystem.addResource(path, input);
-    }
-
-    private static void addResource(final String path, final String name)
-    {
-        addResource(path, name, false);
-    }
-
-    private static void addResourceContents(final String path, final String contents)
-    {
-        ResourceFileSystem.addResource(path, new StringResource(contents));
+        ResourceFileSystem.addResource(SHOULD_ALWAYS_SLICE_CONFIGURATION, "osm-pbf-relation.json",
+                false, AtlasLoadingOption.class);
+        ResourceFileSystem.addResource(SLICING_CONFIGURATION, "atlas-relation-slicing.json", false,
+                AtlasLoadingOption.class);
     }
 
     @Test

--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/persistence/FeatureChangeOutputFormatIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/persistence/FeatureChangeOutputFormatIntegrationTest.java
@@ -27,6 +27,9 @@ import scala.Tuple2;
  */
 public class FeatureChangeOutputFormatIntegrationTest
 {
+    /**
+     * @author matthieun
+     */
     private static class TestSparkJob extends SparkJob
     {
         private static final long serialVersionUID = -4875961726986591317L;

--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/persistence/FeatureChangeOutputFormatIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/persistence/FeatureChangeOutputFormatIntegrationTest.java
@@ -1,0 +1,98 @@
+package org.openstreetmap.atlas.generator.persistence;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.JobConf;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
+import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+import org.openstreetmap.atlas.geography.atlas.complete.CompletePoint;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.runtime.CommandMap;
+
+import scala.Tuple2;
+
+/**
+ * @author matthieun
+ */
+public class FeatureChangeOutputFormatIntegrationTest
+{
+    private static class TestSparkJob extends SparkJob
+    {
+        private static final long serialVersionUID = -4875961726986591317L;
+
+        @Override
+        public String getName()
+        {
+            return "FeatureChangeOutputFormatIntegrationTest Spark Job";
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void start(final CommandMap command)
+        {
+            getContext().parallelize(StringList
+                    .split("{\"country\":\"ABC\",\"shard\":\"1-2-3\",\"metadata\":{}};"
+                            + "{\"country\":\"DEF\",\"shard\":\"4-5-6\",\"metadata\":{}};"
+                            + "{\"country\":\"GHI\",\"shard\":\"7-8-9\",\"metadata\":{}}", ";")
+                    .stream().collect(Collectors.toList())).mapToPair(key ->
+                    {
+                        final List<FeatureChange> list = new ArrayList<>();
+                        list.add(FeatureChange
+                                .remove(new CompletePoint(123L, Location.COLOSSEUM, null, null)));
+                        list.add(FeatureChange.remove(
+                                new CompletePoint(456L, Location.EIFFEL_TOWER, null, null)));
+                        return new Tuple2(key, list);
+                    }).saveAsHadoopFile((String) command.get(OUTPUT), Text.class, Atlas.class,
+                            MultipleFeatureChangeOutputFormat.class, new JobConf(configuration()));
+        }
+    }
+
+    private static final String OUTPUT = "resource://test/output";
+    private static final String PATH_1 = OUTPUT + "/ABC/ABC_1-2-3.geojson.gz";
+    private static final String PATH_2 = OUTPUT + "/DEF/DEF_4-5-6.geojson.gz";
+    private static final String PATH_3 = OUTPUT + "/GHI/GHI_7-8-9.geojson.gz";
+
+    @Test
+    public void testSave() throws IOException
+    {
+        final StringList arguments = new StringList();
+        arguments.add("-master=local");
+        arguments.add("-output=" + OUTPUT);
+        arguments.add("-startedFolder=resource://test/started");
+        arguments.add(
+                "-sparkOptions=fs.resource.impl=" + ResourceFileSystem.class.getCanonicalName());
+
+        final String[] args = new String[arguments.size()];
+        for (int i = 0; i < arguments.size(); i++)
+        {
+            args[i] = arguments.get(i);
+        }
+
+        ResourceFileSystem.clear();
+        new TestSparkJob().runWithoutQuitting(args);
+        ResourceFileSystem.printContents();
+        try (ResourceFileSystem resourceFileSystem = new ResourceFileSystem())
+        {
+            Assert.assertTrue(resourceFileSystem.exists(new Path(PATH_1)));
+            Assert.assertEquals(2, Iterables.size(
+                    SparkJob.resource(PATH_1, ResourceFileSystem.simpleconfiguration()).lines()));
+            Assert.assertTrue(resourceFileSystem.exists(new Path(PATH_2)));
+            Assert.assertEquals(2, Iterables.size(
+                    SparkJob.resource(PATH_2, ResourceFileSystem.simpleconfiguration()).lines()));
+            Assert.assertTrue(resourceFileSystem.exists(new Path(PATH_3)));
+            Assert.assertEquals(2, Iterables.size(
+                    SparkJob.resource(PATH_3, ResourceFileSystem.simpleconfiguration()).lines()));
+        }
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/FeatureChangeOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/FeatureChangeOutputFormat.java
@@ -1,0 +1,43 @@
+package org.openstreetmap.atlas.generator.persistence;
+
+import java.io.Writer;
+import java.util.List;
+
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+import org.openstreetmap.atlas.streaming.resource.AbstractWritableResource;
+
+/**
+ * @author matthieun
+ */
+public class FeatureChangeOutputFormat extends AbstractFileOutputFormat<List<FeatureChange>>
+{
+    @Override
+    protected String fileExtension()
+    {
+        return ".geojson";
+    }
+
+    @Override
+    protected boolean isCompressed()
+    {
+        return true;
+    }
+
+    @Override
+    protected void save(final List<FeatureChange> value, final AbstractWritableResource out)
+    {
+        try (Writer writer = out.writer())
+        {
+            for (final FeatureChange featureChange : value)
+            {
+                writer.write(featureChange.toGeoJson());
+                writer.write(System.lineSeparator());
+            }
+        }
+        catch (final Exception e)
+        {
+            throw new CoreException("Unable to save {}!", out.getName(), e);
+        }
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/FeatureChangeOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/FeatureChangeOutputFormat.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
 import org.openstreetmap.atlas.streaming.resource.AbstractWritableResource;
+import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 
 /**
  * @author matthieun
@@ -15,7 +16,7 @@ public class FeatureChangeOutputFormat extends AbstractFileOutputFormat<List<Fea
     @Override
     protected String fileExtension()
     {
-        return ".geojson";
+        return FileSuffix.GEO_JSON.toString();
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleFeatureChangeOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleFeatureChangeOutputFormat.java
@@ -1,0 +1,31 @@
+package org.openstreetmap.atlas.generator.persistence;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.util.Progressable;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+
+/**
+ * @author matthieun
+ */
+public class MultipleFeatureChangeOutputFormat
+        extends AbstractMultipleAtlasBasedOutputFormat<List<FeatureChange>>
+{
+    private FeatureChangeOutputFormat format = null;
+
+    @Override
+    protected RecordWriter<String, List<FeatureChange>> getBaseRecordWriter(
+            final FileSystem fileSystem, final JobConf job, final String name,
+            final Progressable progress) throws IOException
+    {
+        if (this.format == null)
+        {
+            this.format = new FeatureChangeOutputFormat();
+        }
+        return this.format.getRecordWriter(fileSystem, job, name, progress);
+    }
+}


### PR DESCRIPTION
### Description:

Added a new `FeatureChangeOutputFormat` to be able to save RDDs of lists of `FeatureChange`s.

Also:
- Fixed a few sonar errors
- Aggregated the addResource methods to ResourceFileSystem

### Potential Impact:

None

### Unit Test Approach:

Added one integration test

### Test Results:

pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
