### PR TITLE
Reworked atlas fetcher function to improve performance

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/slicing/DynamicRelationSlicingIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/slicing/DynamicRelationSlicingIntegrationTest.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.generator.tools.caching.HadoopAtlasFileCache;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
 import org.openstreetmap.atlas.geography.Polygon;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.geography.atlas.builder.text.TextAtlasBuilder;
 import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
@@ -86,13 +87,17 @@ public class DynamicRelationSlicingIntegrationTest
 
         final CountryShard initialShardABC = CountryShard.forName("ABC_1-0-0");
         final CountryShard initialShardDEF = CountryShard.forName("DEF_1-1-1");
+        final AtlasResourceLoader loader = new AtlasResourceLoader();
+
+        final Atlas rawAtlasABC = loader.load(lineSlicedAtlasCache
+                .get(initialShardABC.getCountry(), initialShardABC.getShard()).get());
+        final Atlas rawAtlasDEF = loader.load(lineSlicedAtlasCache
+                .get(initialShardDEF.getCountry(), initialShardDEF.getShard()).get());
 
         final Function<Shard, Optional<Atlas>> atlasFetcherABC = AtlasGeneratorHelper.atlasFetcher(
-                lineSlicedAtlasCache, lineSlicedAtlasCache, boundaryMap, "ABC",
-                initialShardDEF.getShard());
+                lineSlicedAtlasCache, rawAtlasABC, boundaryMap, "ABC", initialShardDEF.getShard());
         final Function<Shard, Optional<Atlas>> atlasFetcherDEF = AtlasGeneratorHelper.atlasFetcher(
-                lineSlicedAtlasCache, lineSlicedAtlasCache, boundaryMap, "DEF",
-                initialShardDEF.getShard());
+                lineSlicedAtlasCache, rawAtlasDEF, boundaryMap, "DEF", initialShardDEF.getShard());
 
         // the operation we are testing
 

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -218,8 +218,6 @@ public class AtlasGenerator extends SparkJob
                         broadcastLoadingOptions, broadcastSharding,
                         getAlternateSubFolderOutput(output,
                                 AtlasGeneratorJobGroup.LINE_SLICED_SUB.getCacheFolder()),
-                        getAlternateSubFolderOutput(output,
-                                AtlasGeneratorJobGroup.LINE_SLICED.getCacheFolder()),
                         atlasScheme, sparkContext))
                 .filter(tuple -> tuple._2() != null);
         fullySlicedRawAtlasShardsRDD.cache();

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -499,7 +499,8 @@ public final class AtlasGeneratorHelper implements Serializable
     protected static PairFunction<Tuple2<String, Atlas>, String, Atlas> sliceRelations(
             final Broadcast<CountryBoundaryMap> boundaries,
             final Broadcast<Map<String, String>> loadingOptions, final Broadcast<Sharding> sharding,
-            final String lineSlicedSubAtlasPath, final SlippyTilePersistenceScheme atlasScheme, final Map<String, String> sparkContext)
+            final String lineSlicedSubAtlasPath, final SlippyTilePersistenceScheme atlasScheme,
+            final Map<String, String> sparkContext)
     {
         return tuple ->
         {


### PR DESCRIPTION
### Description:
During relation slicing, the Atlas being sliced is dynamically expanded upon to complete any multipolygon relations. However, until now, the Atlas fetcher function used for this dynamic expansion has been inefficient-- it defaulted to fetching the Atlas for the initial shard from a HadoopAtlasFileCache. This approach ignores that the RDD value for the relation slicing already has the Atlas data for the initial shard stored, so now the fetcher stores that value and will return it directly instead of attempting to load from the HadoopAtlasFileCache.

### Potential Impact:
Fewer HadoopAtlasFileCache calls, so possibly improved performance, but otherwise no impact.

### Unit Test Approach:
N/A

### Test Results:
N/A

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
