### PR TITLE
Replace AtlasDelta with AtlasDiff based approach

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '8.18',
-    atlas: '5.8.4',
+    atlas: '5.8.9',
     spark: '2.4.0-cdh6.2.0',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGenerator.java
@@ -20,7 +20,7 @@ import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
 import org.openstreetmap.atlas.generator.tools.spark.persistence.PersistenceTools;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
 import org.openstreetmap.atlas.geography.atlas.statistics.AtlasStatistics;
 import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
@@ -250,7 +250,7 @@ public class AtlasGenerator extends SparkJob
                                 AtlasGeneratorJobGroup.EDGE_SUB.getCacheFolder()),
                         getAlternateSubFolderOutput(output,
                                 AtlasGeneratorJobGroup.FULLY_SLICED.getCacheFolder()),
-                        atlasScheme, tasks));
+                        atlasScheme));
         countryAtlasShardsRDD.cache();
         saveAsHadoop(countryAtlasShardsRDD, AtlasGeneratorJobGroup.WAY_SECTIONED_PBF, output);
         this.copyToOutput(command, pbfPath, getAlternateSubFolderOutput(output,
@@ -321,9 +321,11 @@ public class AtlasGenerator extends SparkJob
         // Compute the deltas, if needed
         if (!previousOutputForDelta.isEmpty())
         {
-            final JavaPairRDD<String, AtlasDelta> deltasRDD = countryAtlasShardsRDD.flatMapToPair(
-                    AtlasGeneratorHelper.computeAtlasDelta(sparkContext, previousOutputForDelta));
-            saveAsHadoop(deltasRDD, AtlasGeneratorJobGroup.DELTAS, output);
+            final JavaPairRDD<String, List<FeatureChange>> diffsRDD = countryAtlasShardsRDD
+                    .mapToPair(AtlasGeneratorHelper.computeAtlasDiff(sparkContext,
+                            previousOutputForDelta))
+                    .filter(tuple -> tuple._2() != null);
+            saveAsHadoop(diffsRDD, AtlasGeneratorJobGroup.DIFFS, output);
         }
 
         if (shouldIncludeFilteredOutputConfiguration != null)
@@ -348,7 +350,7 @@ public class AtlasGenerator extends SparkJob
         }
         catch (final Exception exception)
         {
-            logger.warn(EXCEPTION_MESSAGE, AtlasGeneratorJobGroup.DELTAS.getDescription(),
+            logger.warn(EXCEPTION_MESSAGE, AtlasGeneratorJobGroup.DIFFS.getDescription(),
                     exception);
         }
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorJobGroup.java
@@ -1,13 +1,14 @@
 package org.openstreetmap.atlas.generator;
 
+import java.util.List;
+
 import org.apache.hadoop.mapred.lib.MultipleOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasCountryStatisticsOutputFormat;
+import org.openstreetmap.atlas.generator.persistence.MultipleAtlasFeatureChangeOutput;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasProtoOutputFormat;
 import org.openstreetmap.atlas.generator.persistence.MultipleAtlasStatisticsOutputFormat;
-import org.openstreetmap.atlas.generator.persistence.delta.RemovedMultipleAtlasDeltaOutputFormat;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.atlas.geography.atlas.delta.AtlasDelta;
 import org.openstreetmap.atlas.geography.atlas.statistics.AtlasStatistics;
 
 /**
@@ -58,12 +59,7 @@ public enum AtlasGeneratorJobGroup
             "countryStats",
             AtlasStatistics.class,
             MultipleAtlasCountryStatisticsOutputFormat.class),
-    DELTAS(
-            8,
-            "Atlas Deltas Creation",
-            "deltas",
-            AtlasDelta.class,
-            RemovedMultipleAtlasDeltaOutputFormat.class),
+    DIFFS(8, "Atlas Diff Creation", "diffs", List.class, MultipleAtlasFeatureChangeOutput.class),
     TAGGABLE_FILTERED_OUTPUT(
             9,
             "Taggable Filtered SubAtlas Creation",

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/AtlasProtoOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/AtlasProtoOutputFormat.java
@@ -9,7 +9,7 @@ import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 
 /**
  * {@link FileOutputFormat} that writes an {@link Atlas} in protocol buffer format.
- * 
+ *
  * @author lcram
  */
 public class AtlasProtoOutputFormat extends AbstractFileOutputFormat<Atlas>

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasFeatureChangeOutput.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasFeatureChangeOutput.java
@@ -1,0 +1,33 @@
+package org.openstreetmap.atlas.generator.persistence;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.util.Progressable;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+
+/**
+ * @author samg
+ */
+public class MultipleAtlasFeatureChangeOutput
+        extends AbstractMultipleAtlasBasedOutputFormat<List<FeatureChange>>
+{
+
+    private FeatureChangeOutputFormat format = null;
+
+    @Override
+    protected RecordWriter<String, List<FeatureChange>> getBaseRecordWriter(
+            final FileSystem fileSystem, final JobConf job, final String name,
+            final Progressable progress) throws IOException
+    {
+        if (this.format == null)
+        {
+            this.format = new FeatureChangeOutputFormat();
+        }
+        return this.format.getRecordWriter(fileSystem, job, name, progress);
+    }
+
+}


### PR DESCRIPTION
### Description:
This PR replaces the AtlasDelta step with AtlasDiff, a replacement with similar functionality but based on the `AtlasDiff` class for comparing two Atlases. Passing in output from a previous Atlas generation, AtlasDiff will attempt to compare any newly generated Atlases to ones from the previous output. Brief summary logs for object types and tags will be generated, then a GeoJSON diff for the Atlases will be saved to the output folder.

Depends on https://github.com/osmlab/atlas/pull/579

### Potential Impact:
Minimal, this approach is a more robust AtlasDelta. However, any reliance on AtlasDelta reports will need to be updated, and it's possible that more updates will be needed to augment AtlasDiff as part of supporting anyone making that transition.

### Unit Test Approach:
N/A
### Test Results:
N/A

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
