### PR TITLE
Fix Json key issue with AtlasStatistics

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -34,6 +34,8 @@ public class AtlasGeneratorIntegrationTest
     public static final String ATLAS_OUTPUT = "resource://test/atlas";
     public static final String LINE_DELIMITED_GEOJSON_OUTPUT = "resource://test/"
             + AtlasGenerator.LINE_DELIMITED_GEOJSON_STATISTICS_FOLDER + "/DMA";
+    public static final String COUNTRY_STATS = "resource://test/countryStats";
+    public static final String SHARD_STATS = "resource://test/shardStats";
     public static final String CONFIGURED_OUTPUT_FILTER = "resource://test/filter/nothingFilter.json";
     public static final String FILTER_NAME = "nothingFilter";
     public static final String CONFIGURATION = "resource://test/configuration";
@@ -150,6 +152,15 @@ public class AtlasGeneratorIntegrationTest
                     new Path("resource://test/configuredOutput/DMA/9/DMA_9-168-233.atlas")));
             Assert.assertTrue(resourceFileSystem.exists(
                     new Path("resource://test/configuredOutput/DMA/9/DMA_9-168-234.atlas")));
+
+            final String countryStats = resourceForName(resourceFileSystem,
+                    COUNTRY_STATS + "/DMA.csv.gz").all();
+            final String shard933Stats = resourceForName(resourceFileSystem,
+                    SHARD_STATS + "/DMA/9/DMA_9-168-233.csv.gz").all();
+            final String shard934Stats = resourceForName(resourceFileSystem,
+                    SHARD_STATS + "/DMA/9/DMA_9-168-234.csv.gz").all();
+            Assert.assertNotEquals(countryStats, shard933Stats);
+            Assert.assertNotEquals(countryStats, shard934Stats);
         }
         catch (IllegalArgumentException | IOException e)
         {

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -41,6 +41,7 @@ import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.tags.Taggable;
+import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.configuration.ConfiguredFilter;
 import org.openstreetmap.atlas.utilities.runtime.system.memory.Memory;
@@ -336,6 +337,21 @@ public final class AtlasGeneratorHelper implements Serializable
             final String persistenceKey = PersistenceJsonParser.createJsonKey(countryName,
                     shard.getName(), atlasScheme.getScheme());
             return new Tuple2<>(persistenceKey, atlas);
+        };
+    }
+
+    protected static PairFunction<Tuple2<String, AtlasStatistics>, String, NamedAtlasStatistics> groupAtlasStatisticsByCountry()
+    {
+        return tuple ->
+        {
+            final CountryShard countryShardName = getCountryShard(tuple._1());
+            final String countryName = countryShardName.getCountry();
+            return new Tuple2<>(
+                    // Create the same key for all shards in the same country
+                    PersistenceJsonParser.createJsonKey(countryName, "N/A", Maps.hashMap()),
+                    // Here using NamedAtlasStatistics so the reduceByKey function below can
+                    // name what statistic merging failed, if any.
+                    new NamedAtlasStatistics(countryName, tuple._2()));
         };
     }
 


### PR DESCRIPTION
### Description:

When the RDD keys were switched to JSON in #123 country AtlasStatistics were not upgraded by mistake. The integration test did not fail either since the merging of the shard statistics was taking the last shard statistics object available, making it look valid.

This PR fixes that omission and adds steps to the integration test to make sure it does not happen again.

### Potential Impact:

Country Statistics are back to normal numbers.

### Unit Test Approach:

Updated integration test

### Test Results:

pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
