### PR TITLE
JDK 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AtlasGenerator is a Spark Job that generates [Atlas](https://github.com/osmlab/a
 
 ## Getting started
 
-This project has been implemented and tested with Oracle JDK 1.8.
+This project has been implemented and tested with OpenJDK 11
 
 ### Build
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ apply from: 'gradle/execution.gradle'
 
 description = "Atlas Generator Library"
 
-sourceCompatibility=1.8
-targetCompatibility=1.8
+sourceCompatibility=11
+targetCompatibility=11
 
 repositories
 {
@@ -37,6 +37,12 @@ repositories
 
 configurations
 {
+    all {
+        resolutionStrategy {
+            // Force jackson 2.6.7 for Spark
+            force 'com.fasterxml.jackson.core:jackson-core:2.6.7', 'com.fasterxml.jackson.core:jackson-databind:2.6.7', 'com.fasterxml.jackson.core:jackson-annotations:2.6.7'
+        }
+    }
     compile
     {
         resolutionStrategy
@@ -142,6 +148,6 @@ gradle.startParameter.excludedTaskNames += skippedTaskNames
 
 idea {
     project {
-        languageLevel = '1.8'
+        languageLevel = '11'
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '5.9.0',
+    atlas: '6.0.0',
     spark: '2.4.4',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,8 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '5.9.1',
-    spark: '2.4.0-cdh6.2.0',
+    atlas: '5.9.0',
+    spark: '2.4.4',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.openstreetmap.atlas
-version=4.4.7-SNAPSHOT
+version=5.0.0-SNAPSHOT
 
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
### Description:
Small diff but big change-- atlas-generator will now target JDK 11! Additionally, the Spark version has been updated from 2.4.0 to 2.4.4

Will require the merge and release of changes from https://github.com/osmlab/atlas/pull/592

### Potential Impact:
This PR changes the target build version to support JDK 11, which means that the resulting JARs will likely not run on anything less than JDK 11.

### Unit Test Approach:

### Test Results:

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
