### PR TITLE
Depend on latest Atlas 5.9.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '5.9.0',
+    atlas: '5.9.1',
     spark: '2.4.0-cdh6.2.0',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
@@ -38,7 +38,7 @@ public class AtlasShardVerifier extends Command
         @SuppressWarnings("unchecked")
         final Set<CountryShard> expectedShards = (Set<CountryShard>) command.get(EXPECTED_SHARDS);
         final Set<CountryShard> existingShards = atlasFolder.listFilesRecursively().stream()
-                .filter(AtlasResourceLoader.IS_ATLAS).map(File::getName)
+                .filter(AtlasResourceLoader.HAS_ATLAS_EXTENSION).map(File::getName)
                 .map(name -> StringList.split(name, ".").get(0)).map(CountryShard::forName)
                 .collect(Collectors.toSet());
         expectedShards.removeAll(existingShards);


### PR DESCRIPTION
### Description:

Depend on latest Atlas 5.9.1

### Potential Impact:

This release contains a breaking change for AtlasResourceLoader

### Unit Test Approach:

Existing tests

### Test Results:

Existing tests

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
