### PR TITLE
Fix CoreException during AtlasDiff

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -200,7 +200,8 @@ public final class AtlasGeneratorHelper implements Serializable
                                     countryShardName);
             if (!alter.isPresent())
             {
-                throw new CoreException("No atlas found for {}!", countryShardName);
+                logger.error("No atlas found for {}!", countryShardName);
+                return new Tuple2<>(tuple._1(), null);
             }
 
             final Optional<Change> diffChange = new AtlasDiff(alter.get(), current)


### PR DESCRIPTION
### Description:
When an older Atlas file isn't found, log it as empty instead of throwing CoreException.

### Potential Impact:
None.
### Unit Test Approach:
N/A
### Test Results:
N/A
------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
