### PR TITLE
Do not re-gzip when dumping ResourceFileSystem to disk

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
@@ -117,6 +117,7 @@ public class ResourceFileSystem extends FileSystem
         {
             final String subPath = file.substring(String.valueOf(SCHEME + "://").length());
             final File output = folder.child(subPath);
+            output.withCompressor(Compressor.NONE);
             STORE.get(file).copyTo(output);
         });
     }


### PR DESCRIPTION
### Description:

`ResourceFileSystem` is used to mock a `Filesystem` for integration tests. The option to copy its contents to disk was erroneously re-gzipping the contents of files ending in `.gz`. This PR fixes that issue!

### Potential Impact:

Better representation of the data when debugging

### Unit Test Approach:

None, this is for tests.

### Test Results:

N/A

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
