### PR TITLE
Prevent NPE in AtlasSharding when resource does not exist

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasSharding.java
@@ -11,6 +11,7 @@ import org.openstreetmap.atlas.geography.sharding.DynamicTileSharding;
 import org.openstreetmap.atlas.geography.sharding.GeoHashSharding;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.geography.sharding.SlippyTileSharding;
+import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 
 /**
@@ -59,8 +60,13 @@ public final class AtlasSharding
         }
         if ("dynamic".equals(split.get(0)))
         {
-            return new DynamicTileSharding(SparkJob.resource(split.get(1),
-                    ConfigurationConverter.hadoopToMapConfiguration(configuration)));
+            final Resource shardingResource = SparkJob.resource(split.get(1),
+                    ConfigurationConverter.hadoopToMapConfiguration(configuration));
+            if (shardingResource == null)
+            {
+                throw new CoreException("Sharding resource does not exist: {}", sharding);
+            }
+            return new DynamicTileSharding(shardingResource);
         }
         throw new CoreException("Sharding type {} is not recognized.", split.get(0));
     }

--- a/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasShardingTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasShardingTest.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.generator.sharding;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
 import org.openstreetmap.atlas.geography.sharding.GeoHashSharding;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
@@ -11,6 +12,13 @@ import org.openstreetmap.atlas.geography.sharding.Sharding;
  */
 public class AtlasShardingTest
 {
+    @Test(expected = CoreException.class)
+    public void testDynamicSharding()
+    {
+        AtlasSharding.forString("dynamic@resource://some/file/that/does/not/exist",
+                ResourceFileSystem.simpleconfiguration());
+    }
+
     @Test
     public void testGeoHashSharding()
     {


### PR DESCRIPTION
### Description:

If a `dynamic` resource passed to an `AtlasSharding` constructor did not exist, then a NPE would be thrown. This simple PR updates that to have a better error message.

### Potential Impact:

Better error message.

### Unit Test Approach:

Added one unit test

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
