### PR TITLE
Make AtlasStatistics optional

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -90,6 +90,7 @@ public class AtlasGeneratorIntegrationTest
         arguments.add("-atlasScheme=zz/");
         arguments.add("-lineDelimitedGeojsonOutput=true");
         arguments.add("-copyShardingAndBoundaries=true");
+        arguments.add("-statistics=true");
         arguments.add("-configuredOutputFilter=" + CONFIGURED_OUTPUT_FILTER);
         arguments.add("-configuredFilterName=" + FILTER_NAME);
         arguments.add("-" + AtlasGeneratorParameters.EDGE_CONFIGURATION.getName() + "="

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -100,6 +100,9 @@ public final class AtlasGeneratorParameters
     public static final Switch<String> CONFIGURED_FILTER_NAME = new Switch<>("configuredFilterName",
             "Name of the filter to be used for configured output", StringConverter.IDENTITY,
             Optionality.OPTIONAL);
+    public static final Switch<Boolean> STATISTICS = new Switch<>("statistics",
+            "Whether to run the shard statistics and country statistics", Boolean::parseBoolean,
+            Optionality.OPTIONAL, "false");
 
     public static ConfiguredFilter getConfiguredFilterFrom(final String name, final String path,
             final Map<String, String> configurationMap)
@@ -135,6 +138,11 @@ public final class AtlasGeneratorParameters
             final Resource configurationResource)
     {
         return new ConfiguredTaggableFilter(getStandardConfigurationFrom(configurationResource));
+    }
+
+    public static boolean runStatistics(final CommandMap command)
+    {
+        return (boolean) command.get(STATISTICS);
     }
 
     protected static AtlasLoadingOption buildAtlasLoadingOption(final CountryBoundaryMap boundaries,
@@ -245,7 +253,7 @@ public final class AtlasGeneratorParameters
                 ATLAS_SCHEME, SHOULD_ALWAYS_SLICE_CONFIGURATION, LINE_DELIMITED_GEOJSON_OUTPUT,
                 SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION,
                 PersistenceTools.COPY_SHARDING_AND_BOUNDARIES, CONFIGURED_FILTER_OUTPUT,
-                CONFIGURED_FILTER_NAME);
+                CONFIGURED_FILTER_NAME, STATISTICS);
     }
 
     private AtlasGeneratorParameters()


### PR DESCRIPTION
### Description:

The AtlasStatistics portion of AtlasGenerator might not be necessary in all jobs. Here we make it optional with a switch to enable it.

### Potential Impact:

Test jobs will be faster

### Unit Test Approach:

Updated integration test

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
