### PR TITLE
HadoopAtlasFileCache tests now performed sequentially

### DIFF
--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -22,7 +22,14 @@ import org.openstreetmap.atlas.utilities.collections.Maps;
 public class HadoopAtlasFileCacheTest
 {
     @Test
-    public void testCache()
+    public void testSequentially()
+    {
+        testCache();
+        testCachesWithDifferentNamespaces();
+        testNonexistentResource();
+    }
+
+    private void testCache()
     {
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");
@@ -72,8 +79,7 @@ public class HadoopAtlasFileCacheTest
         }
     }
 
-    @Test
-    public void testCachesWithDifferentNamespaces()
+    private void testCachesWithDifferentNamespaces()
     {
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");
@@ -145,8 +151,7 @@ public class HadoopAtlasFileCacheTest
         }
     }
 
-    @Test
-    public void testNonexistentResource()
+    private void testNonexistentResource()
     {
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");


### PR DESCRIPTION
### Description:
We have been seeing a number of cron builds fail in the `HadoopAtlasFileCacheTest`. [See here for example.](https://travis-ci.org/github/osmlab/atlas-generator/builds/630884931)

My hunch is that this is due to JUnit running the tests in `HadoopAtlasFileCacheTest` in parallel, and some of the tests may be stepping on each other's toes (since they are hitting the global filesystem presumably at /tmp).

This PR aims to force JUnit to run the tests sequentially.

### Potential Impact:
Hopefully 🤞we stop seeing cron build failures.

### Unit Test Approach:
See changes. We updated a unit test.

### Test Results:
Test runs OK. We can only become increasingly more confident that the bug has been fixed as we continue to see cron build successes.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)