### PR TITLE
Propagate right error message in SparkJob

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/tools/spark/SparkJobIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/tools/spark/SparkJobIntegrationTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
@@ -39,6 +40,37 @@ public class SparkJobIntegrationTest
         try (ResourceFileSystem resourceFileSystem = new ResourceFileSystem())
         {
             Assert.assertTrue(resourceFileSystem.exists(new Path("resource://blah/_SUCCESS")));
+        }
+    }
+
+    @Test
+    public void testFailure() throws IOException
+    {
+        final SparkJob sparkJob = new SparkJob()
+        {
+            private static final long serialVersionUID = -6657905234445292742L;
+
+            @Override
+            public String getName()
+            {
+                return "SparkJobIntegrationTest";
+            }
+
+            @Override
+            public void start(final CommandMap command)
+            {
+                throw new CoreException("Some Job-Specific Failure");
+            }
+        };
+
+        try
+        {
+            sparkJob.runWithoutQuitting(getArguments());
+        }
+        catch (final Exception e)
+        {
+            Assert.assertTrue(
+                    e.getCause().getCause().getMessage().contains("Some Job-Specific Failure"));
         }
     }
 

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java
@@ -361,7 +361,7 @@ public abstract class SparkJob extends Command implements Serializable
         }
         catch (final Exception e)
         {
-            throw new CoreException("Could not write file {}/{}", path, name, e);
+            logger.error("Could not write file {}/{}", path, name, e);
         }
     }
 }


### PR DESCRIPTION
### Description:

When a `SparkJob` failed and the context was cleared before the "FAILED" file could be written to the output folder, the error displayed would be the writing error instead of the actual cause of the job failure.

This PR fixes that by displaying both.

### Potential Impact:

Easier to troubleshoot

### Unit Test Approach:

Added one integration test

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
