### PR TITLE
Removed loading area boundary from metadata tags

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
@@ -99,7 +99,6 @@ public class PbfLoader implements Serializable
                     this.countryShards.stream().map(countryShard -> countryName
                             + Shard.SHARD_DATA_SEPARATOR + countryShard.getName())
                             .collect(Collectors.joining(",")));
-            metaDataTags.put(shard.getName() + "_boundary", loadingArea.toString());
 
             // For each PBF, create an atlas
             pbfPool.forEach(locatedPbf ->


### PR DESCRIPTION
### Description:

Remove the loading area boundary from the raw atlas metadata tag list. When multiatlasing many shards together, this tag was causing the metadata tag list to bloat to unreasonable levels.

### Potential Impact:

Shard loading area will no longer be a tag present in the raw atlas.

### Unit Test Approach:

N/A

### Test Results:

Tested locally, mutliatlases had their size dramatically reduced.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
