### PR TITLE
Save the lastKey and value first to properly populate exception message

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/AbstractFileOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/AbstractFileOutputFormat.java
@@ -74,7 +74,6 @@ public abstract class AbstractFileOutputFormat<T> extends FileOutputFormat<Strin
             @Override
             public void write(final String key, final T value)
             {
-
                 this.lastKey = key;
                 this.lastValue = value;
                 // In case the stream gets corrupted somehow, re-try the upload.

--- a/src/main/java/org/openstreetmap/atlas/generator/persistence/AbstractFileOutputFormat.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/persistence/AbstractFileOutputFormat.java
@@ -74,6 +74,9 @@ public abstract class AbstractFileOutputFormat<T> extends FileOutputFormat<Strin
             @Override
             public void write(final String key, final T value)
             {
+
+                this.lastKey = key;
+                this.lastValue = value;
                 // In case the stream gets corrupted somehow, re-try the upload.
                 retry().run(() ->
                 {
@@ -95,8 +98,6 @@ public abstract class AbstractFileOutputFormat<T> extends FileOutputFormat<Strin
                                 this.path.toString(), e);
                     }
                 });
-                this.lastKey = key;
-                this.lastValue = value;
             }
         };
     }


### PR DESCRIPTION
### Description:

When a file system `close()` fails in `AbstractFileOutputFormat`, and the object written is the first one, the error message would print null. This fixes it by setting the temporary objects first before writing them to the file system.

### Potential Impact:

Better logging

### Unit Test Approach:

Code is already covered by tests

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
