### PR TITLE
AtlasShardVerifier to work with any FileSystem

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
@@ -1,29 +1,49 @@
 package org.openstreetmap.atlas.generator.sharding;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.openstreetmap.atlas.exception.CoreException;
-import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.generator.tools.spark.converters.SparkOptionsStringConverter;
 import org.openstreetmap.atlas.geography.sharding.CountryShard;
-import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.streaming.resource.WritableResource;
 import org.openstreetmap.atlas.streaming.writers.SafeBufferedWriter;
 import org.openstreetmap.atlas.utilities.collections.StringList;
+import org.openstreetmap.atlas.utilities.conversion.StringConverter;
 import org.openstreetmap.atlas.utilities.runtime.Command;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
+import org.openstreetmap.atlas.utilities.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author matthieun
  */
 public class AtlasShardVerifier extends Command
 {
-    private static final Switch<File> ATLAS_FOLDER = new Switch<>("atlasFolder",
-            "Folder containing Atlas Shards named by the AtlasGenerator", File::new);
-    private static final Switch<Set<CountryShard>> EXPECTED_SHARDS = new Switch<>("expectedShards",
-            "Text file containing all the expected shards", value -> new File(value).linesList()
-                    .stream().map(CountryShard::forName).collect(Collectors.toSet()));
-    private static final Switch<File> OUTPUT = new Switch<>("output",
-            "The file to list all the missing shards", File::new);
+    public static final Switch<String> ATLAS_FOLDER = new Switch<>("atlasFolder",
+            "Folder containing Atlas Shards named by the AtlasGenerator", StringConverter.IDENTITY,
+            Optionality.REQUIRED);
+    public static final Switch<String> EXPECTED_SHARDS = new Switch<>("expectedShards",
+            "Path to file containing all the expected shards, or to folder containing reference atlas files",
+            StringConverter.IDENTITY, Optionality.REQUIRED);
+    public static final Switch<String> OUTPUT = new Switch<>("output",
+            "The file to list all the missing shards", StringConverter.IDENTITY,
+            Optionality.REQUIRED);
+    public static final Switch<Map<String, String>> SPARK_OPTIONS = new Switch<>("sparkOptions",
+            "Comma separated list of Spark options, i.e. key1=value1,key2=value2",
+            new SparkOptionsStringConverter(), Optionality.OPTIONAL, "");
+    public static final Switch<Integer> LIST_DEPTH = new Switch<>("listDepth",
+            "Depth to list recursive folders", Integer::valueOf, Optionality.OPTIONAL, "2");
+    public static final Switch<Pattern> PATH_FILTER_REGEX = new Switch<>("pathFilterRegex",
+            "Regex to filter paths to list", Pattern::compile, Optionality.OPTIONAL, ".*\\.atlas");
+
+    private static final Logger logger = LoggerFactory.getLogger(AtlasShardVerifier.class);
 
     public static void main(final String[] args)
     {
@@ -33,14 +53,37 @@ public class AtlasShardVerifier extends Command
     @Override
     protected int onRun(final CommandMap command)
     {
-        final File atlasFolder = (File) command.get(ATLAS_FOLDER);
-        final File output = (File) command.get(OUTPUT);
+        final String atlasFolder = (String) command.get(ATLAS_FOLDER);
+        final int depth = (int) command.get(LIST_DEPTH);
+        final Pattern pattern = (Pattern) command.get(PATH_FILTER_REGEX);
+        logger.debug("Using regex filter \"{}\"", pattern);
+        final PathFilter filter = path -> pattern.matcher(path.toString()).matches();
         @SuppressWarnings("unchecked")
-        final Set<CountryShard> expectedShards = (Set<CountryShard>) command.get(EXPECTED_SHARDS);
-        final Set<CountryShard> existingShards = atlasFolder.listFilesRecursively().stream()
-                .filter(AtlasResourceLoader.HAS_ATLAS_EXTENSION).map(File::getName)
-                .map(name -> StringList.split(name, ".").get(0)).map(CountryShard::forName)
-                .collect(Collectors.toSet());
+        final Map<String, String> sparkConfiguration = (Map<String, String>) command
+                .get(SPARK_OPTIONS);
+        final WritableResource output = FileSystemHelper
+                .writableResource((String) command.get(OUTPUT), sparkConfiguration);
+
+        final String expectedShardsPath = (String) command.get(EXPECTED_SHARDS);
+        final Set<CountryShard> expectedShards;
+        if (FileSystemHelper.isFile(expectedShardsPath, sparkConfiguration))
+        {
+            logger.trace("isFile: {}", expectedShardsPath);
+            expectedShards = FileSystemHelper.resource(expectedShardsPath, sparkConfiguration)
+                    .linesList().stream().map(CountryShard::forName).collect(Collectors.toSet());
+        }
+        else if (FileSystemHelper.isDirectory(expectedShardsPath, sparkConfiguration))
+        {
+            logger.trace("isDirectory: {}", expectedShardsPath);
+            expectedShards = shardsFromFolder(expectedShardsPath, sparkConfiguration, depth,
+                    filter);
+        }
+        else
+        {
+            throw new CoreException("{} does not exist.", expectedShardsPath);
+        }
+        final Set<CountryShard> existingShards = shardsFromFolder(atlasFolder, sparkConfiguration,
+                depth, filter);
         expectedShards.removeAll(existingShards);
         try (SafeBufferedWriter writer = output.writer())
         {
@@ -56,6 +99,24 @@ public class AtlasShardVerifier extends Command
     @Override
     protected SwitchList switches()
     {
-        return new SwitchList().with(ATLAS_FOLDER, EXPECTED_SHARDS, OUTPUT);
+        return new SwitchList().with(ATLAS_FOLDER, EXPECTED_SHARDS, OUTPUT, SPARK_OPTIONS,
+                LIST_DEPTH, PATH_FILTER_REGEX);
+    }
+
+    private Set<CountryShard> shardsFromFolder(final String expectedShardsPath,
+            final Map<String, String> sparkConfiguration, final int depth, final PathFilter filter)
+    {
+        logger.trace("listResourcesRecursively: {}", expectedShardsPath);
+        final Time start = Time.now();
+        final Set<CountryShard> result = FileSystemHelper
+                .streamPathsRecursively(expectedShardsPath, sparkConfiguration, filter, depth)
+                .map(Path::getName)
+                .map(name -> StringList.split(name, "/").last()
+                        .orElseThrow(() -> new CoreException("Path {} not recognized!", name)))
+                .map(name -> StringList.split(name, ".").get(0)).map(CountryShard::forName)
+                .collect(Collectors.toSet());
+        logger.debug("Took {} to find {} countryShards in {}", start.elapsedSince(), result.size(),
+                expectedShardsPath);
+        return result;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
@@ -110,11 +110,8 @@ public class AtlasShardVerifier extends Command
         final Time start = Time.now();
         final Set<CountryShard> result = FileSystemHelper
                 .streamPathsRecursively(expectedShardsPath, sparkConfiguration, filter, depth)
-                .map(Path::getName)
-                .map(name -> StringList.split(name, "/").last()
-                        .orElseThrow(() -> new CoreException("Path {} not recognized!", name)))
-                .map(name -> StringList.split(name, ".").get(0)).map(CountryShard::forName)
-                .collect(Collectors.toSet());
+                .map(Path::getName).map(name -> StringList.split(name, ".").get(0))
+                .map(CountryShard::forName).collect(Collectors.toSet());
         logger.debug("Took {} to find {} countryShards in {}", start.elapsedSince(), result.size(),
                 expectedShardsPath);
         return result;

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
@@ -184,6 +184,13 @@ public class ResourceFileSystem extends FileSystem
         final Resource resource = STORE.get(hadoopPath.toString());
         if (resource == null)
         {
+            for (final String filePath : STORE.keySet())
+            {
+                if (filePath.startsWith(hadoopPath.toString()))
+                {
+                    return new FileStatus(0, true, 0, 0, 0, hadoopPath);
+                }
+            }
             throw new FileNotFoundException();
         }
         return new FileStatus(resource.length(), false, 1, Long.MAX_VALUE, 0, hadoopPath);

--- a/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifierTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifierTest.java
@@ -1,0 +1,91 @@
+package org.openstreetmap.atlas.generator.sharding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
+import org.openstreetmap.atlas.streaming.resource.StringResource;
+import org.openstreetmap.atlas.streaming.resource.WritableResource;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+
+/**
+ * @author matthieun
+ */
+public class AtlasShardVerifierTest
+{
+    private static final String INPUT = "resource://test/input";
+    private static final String CHECK = "resource://test/check";
+    private static final String OUTPUT = "resource://test/output/missing.txt";
+
+    @Before
+    @After
+    public void clean()
+    {
+        ResourceFileSystem.clear();
+    }
+
+    public String[] getArguments()
+    {
+        final StringList sparkConfiguration = new StringList();
+        ResourceFileSystem.simpleconfiguration().entrySet().stream()
+                .forEach(entry -> sparkConfiguration.add(entry.getKey() + "=" + entry.getValue()));
+
+        final List<String> arguments = new ArrayList<>();
+        arguments.add("-" + AtlasShardVerifier.ATLAS_FOLDER.getName() + "=" + INPUT);
+        arguments.add("-" + AtlasShardVerifier.OUTPUT.getName() + "=" + OUTPUT);
+        arguments.add("-" + AtlasShardVerifier.EXPECTED_SHARDS.getName() + "=" + CHECK);
+        arguments.add("-" + AtlasShardVerifier.SPARK_OPTIONS.getName() + "="
+                + sparkConfiguration.join(","));
+
+        final String[] args = new String[arguments.size()];
+        for (int i = 0; i < arguments.size(); i++)
+        {
+            args[i] = arguments.get(i);
+        }
+        return args;
+    }
+
+    @Test
+    public void testCommandFromDirectory()
+    {
+        final WritableResource atlas = new StringResource("blah");
+
+        ResourceFileSystem.addResource(CHECK + "/ABC/ABC_10-11-12.atlas", atlas);
+        ResourceFileSystem.addResource(CHECK + "/ABC/ABC_10-11-13.atlas", atlas);
+        ResourceFileSystem.addResource(CHECK + "/ABC/ABC_10-11-14.atlas", atlas);
+        ResourceFileSystem.addResource(CHECK + "/ABC/ABC_10-11-15.atlas", atlas);
+
+        ResourceFileSystem.addResource(INPUT + "/ABC/ABC_10-11-12.atlas", atlas);
+        ResourceFileSystem.addResource(INPUT + "/ABC/ABC_10-11-13.atlas", atlas);
+        ResourceFileSystem.addResource(INPUT + "/ABC/ABC_10-11-14.atlas", atlas);
+
+        new AtlasShardVerifier().runWithoutQuitting(getArguments());
+
+        Assert.assertEquals("ABC_10-11-15",
+                FileSystemHelper.resource(OUTPUT, ResourceFileSystem.simpleconfiguration()).all());
+    }
+
+    @Test
+    public void testCommandFromFile()
+    {
+        final WritableResource atlas = new StringResource("blah");
+        final WritableResource check = new StringResource(
+                "ABC_10-11-12\nABC_10-11-13\nABC_10-11-14\nABC_10-11-15");
+
+        ResourceFileSystem.addResource(CHECK, check);
+
+        ResourceFileSystem.addResource(INPUT + "/ABC/ABC_10-11-12.atlas", atlas);
+        ResourceFileSystem.addResource(INPUT + "/ABC/ABC_10-11-13.atlas", atlas);
+        ResourceFileSystem.addResource(INPUT + "/ABC/ABC_10-11-14.atlas", atlas);
+
+        new AtlasShardVerifier().runWithoutQuitting(getArguments());
+
+        Assert.assertEquals("ABC_10-11-15",
+                FileSystemHelper.resource(OUTPUT, ResourceFileSystem.simpleconfiguration()).all());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifierTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifierTest.java
@@ -38,6 +38,7 @@ public class AtlasShardVerifierTest
         final List<String> arguments = new ArrayList<>();
         arguments.add("-" + AtlasShardVerifier.ATLAS_FOLDER.getName() + "=" + INPUT);
         arguments.add("-" + AtlasShardVerifier.OUTPUT.getName() + "=" + OUTPUT);
+        arguments.add("-" + AtlasShardVerifier.COUNTRIES.getName() + "=ABC");
         arguments.add("-" + AtlasShardVerifier.EXPECTED_SHARDS.getName() + "=" + CHECK);
         arguments.add("-" + AtlasShardVerifier.SPARK_OPTIONS.getName() + "="
                 + sparkConfiguration.join(","));
@@ -86,6 +87,26 @@ public class AtlasShardVerifierTest
         new AtlasShardVerifier().runWithoutQuitting(getArguments());
 
         Assert.assertEquals("ABC_10-11-15",
+                FileSystemHelper.resource(OUTPUT, ResourceFileSystem.simpleconfiguration()).all());
+    }
+
+    @Test
+    public void testCountryFiltering()
+    {
+        final WritableResource atlas = new StringResource("blah");
+
+        ResourceFileSystem.addResource(CHECK + "/ABC/ABC_10-11-12.atlas", atlas);
+        ResourceFileSystem.addResource(CHECK + "/ABC/ABC_10-11-13.atlas", atlas);
+        ResourceFileSystem.addResource(CHECK + "/DEF/DEF_10-11-14.atlas", atlas);
+        ResourceFileSystem.addResource(CHECK + "/DEF/DEF_10-11-15.atlas", atlas);
+
+        ResourceFileSystem.addResource(INPUT + "/ABC/ABC_10-11-12.atlas", atlas);
+        ResourceFileSystem.addResource(INPUT + "/XYZ/XYZ_10-11-13.atlas", atlas);
+        ResourceFileSystem.addResource(INPUT + "/DEF/DEF_10-11-14.atlas", atlas);
+
+        new AtlasShardVerifier().runWithoutQuitting(getArguments());
+
+        Assert.assertEquals("ABC_10-11-13",
                 FileSystemHelper.resource(OUTPUT, ResourceFileSystem.simpleconfiguration()).all());
     }
 }


### PR DESCRIPTION
### Description:

The AtlasShardVerifier is a command that makes sure that a folder containing Atlas files has all the expected shards. New features are:
- The reference can now be:
  - A file containing a list of expected shards
  - A path to a directory containing Atlas files
- The directory to check does not have to be on the local file system, it can be on any hadoop `FileSystem`

### Potential Impact:

More use cases supported

### Unit Test Approach:

- Added one unit test
- Fixed integration test

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
