### PR TITLE
Remove failure condition from AtlasShardVerifier

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasShardVerifier.java
@@ -2,7 +2,6 @@ package org.openstreetmap.atlas.generator.sharding;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -119,17 +118,6 @@ public class AtlasShardVerifier extends Command
         catch (final Exception e)
         {
             throw new CoreException("Verification failed", e);
-        }
-        if (!expectedShards.isEmpty())
-        {
-            if (logger.isErrorEnabled())
-            {
-                logger.error("Missing shards:\n{}",
-                        new StringList(new TreeSet<>(expectedShards.stream()
-                                .map(CountryShard::getName).collect(Collectors.toSet())))
-                                        .join(System.lineSeparator()));
-            }
-            return 1;
         }
         return 0;
     }


### PR DESCRIPTION
### Description:

In https://github.com/osmlab/atlas-generator/pull/154 a failure condition was added to `AtlasShardVerifier`, which would fail the command if there were any "missing" shards. However, these missing shards are calculated by taking the difference of the expected shards, and the shards that were actually built. This difference is therefore not a set of confirmed missing shards, but instead a list of shards that could potentially missing. This set of shards needs to be fed into an overpass query to see if they are legitimately empty or not. Failing here is premature, and therefore has been removed.

### Potential Impact:

Removes early failure condition.
### Unit Test Approach:

Existing tests.

### Test Results:

Tests pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
