### PR TITLE
Add ability to create multiple filtered atlases with configured output filter

### DIFF
--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -40,7 +40,9 @@ public class AtlasGeneratorIntegrationTest
     public static final String COUNTRY_STATS = "resource://test/countryStats";
     public static final String SHARD_STATS = "resource://test/shardStats";
     public static final String CONFIGURED_OUTPUT_FILTER = "resource://test/filter/nothingFilter.json";
+    public static final String CONFIGURED_OUTPUT_FILTER_2 = "resource://test/filter/highwayFilter.json";
     public static final String FILTER_NAME = "nothingFilter";
+    public static final String FILTER_NAME_2 = "highwayFilter";
     public static final String CONFIGURATION = "resource://test/configuration";
     public static final String EDGE_CONFIGURATION = CONFIGURATION + "/atlas-edge.json";
     public static final String WAY_SECTIONING_CONFIGURATION = CONFIGURATION
@@ -69,6 +71,7 @@ public class AtlasGeneratorIntegrationTest
         ResourceFileSystem.addResource(INPUT_SHARDING, "tree-6-14-100000.txt");
         ResourceFileSystem.addResource(INPUT_BOUNDARIES, "DMA.txt", true);
         ResourceFileSystem.addResource(CONFIGURED_OUTPUT_FILTER, "nothingFilter.json");
+        ResourceFileSystem.addResource(CONFIGURED_OUTPUT_FILTER_2, "highwayFilter.json");
         ResourceFileSystem.addResourceContents(INPUT_BOUNDARIES_META, "Meta data for boundaries");
         ResourceFileSystem.addResourceContents(INPUT_SHARDING_META, "Meta data for sharding");
         ResourceFileSystem.addResource(EDGE_CONFIGURATION, "atlas-edge.json", false,
@@ -105,8 +108,9 @@ public class AtlasGeneratorIntegrationTest
         arguments.add("-lineDelimitedGeojsonOutput=true");
         arguments.add("-copyShardingAndBoundaries=true");
         arguments.add("-statistics=true");
-        arguments.add("-configuredOutputFilter=" + CONFIGURED_OUTPUT_FILTER);
-        arguments.add("-configuredFilterName=" + FILTER_NAME);
+        arguments.add("-configuredOutputFilter=" + CONFIGURED_OUTPUT_FILTER + ","
+                + CONFIGURED_OUTPUT_FILTER_2);
+        arguments.add("-configuredFilterName=" + FILTER_NAME + "," + FILTER_NAME_2);
         arguments.add("-" + AtlasGeneratorParameters.EDGE_CONFIGURATION.getName() + "="
                 + EDGE_CONFIGURATION);
         arguments.add("-" + AtlasGeneratorParameters.WAY_SECTIONING_CONFIGURATION.getName() + "="
@@ -162,10 +166,14 @@ public class AtlasGeneratorIntegrationTest
             Assert.assertTrue(resourceFileSystem.exists(new Path(
                     SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_META))));
 
-            Assert.assertTrue(resourceFileSystem.exists(
-                    new Path("resource://test/configuredOutput/DMA/9/DMA_9-168-233.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(
-                    new Path("resource://test/configuredOutput/DMA/9/DMA_9-168-234.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(new Path("resource://test/configuredOutput/"
+                    + FILTER_NAME + "/DMA/9/DMA_9-168-233.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(new Path("resource://test/configuredOutput/"
+                    + FILTER_NAME + "/DMA/9/DMA_9-168-234.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(new Path("resource://test/configuredOutput/"
+                    + FILTER_NAME_2 + "/DMA/9/DMA_9-168-233.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(new Path("resource://test/configuredOutput/"
+                    + FILTER_NAME_2 + "/DMA/9/DMA_9-168-234.atlas")));
 
             final String countryStats = resourceForName(resourceFileSystem,
                     COUNTRY_STATS + "/DMA.csv.gz").all();
@@ -199,8 +207,9 @@ public class AtlasGeneratorIntegrationTest
         arguments.add("-sharding=geohash@4");
         arguments.add("-lineDelimitedGeojsonOutput=true");
         arguments.add("-copyShardingAndBoundaries=true");
-        arguments.add("-configuredOutputFilter=" + CONFIGURED_OUTPUT_FILTER);
-        arguments.add("-configuredFilterName=" + FILTER_NAME);
+        arguments.add("-configuredOutputFilter=" + CONFIGURED_OUTPUT_FILTER + ","
+                + CONFIGURED_OUTPUT_FILTER_2);
+        arguments.add("-configuredFilterName=" + FILTER_NAME + "," + FILTER_NAME_2);
         arguments.add("-" + SparkJob.SPARK_OPTIONS.getName() + "=" + sparkConfiguration.join(","));
 
         final String[] args = new String[arguments.size()];
@@ -238,10 +247,14 @@ public class AtlasGeneratorIntegrationTest
             Assert.assertTrue(resourceFileSystem.exists(new Path(
                     SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_META))));
 
-            Assert.assertTrue(resourceFileSystem
-                    .exists(new Path("resource://test/configuredOutput/DMA/DMA_ddsq.atlas")));
-            Assert.assertTrue(resourceFileSystem
-                    .exists(new Path("resource://test/configuredOutput/DMA/DMA_ddsr.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(new Path(
+                    "resource://test/configuredOutput/" + FILTER_NAME + "/DMA/DMA_ddsq.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(new Path(
+                    "resource://test/configuredOutput/" + FILTER_NAME + "/DMA/DMA_ddsr.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(new Path(
+                    "resource://test/configuredOutput/" + FILTER_NAME_2 + "/DMA/DMA_ddsq.atlas")));
+            Assert.assertFalse(resourceFileSystem.exists(new Path(
+                    "resource://test/configuredOutput/" + FILTER_NAME_2 + "/DMA/DMA_ddsr.atlas")));
         }
         catch (IllegalArgumentException | IOException e)
         {

--- a/src/integrationTest/resources/org/openstreetmap/atlas/generator/highwayFilter.json
+++ b/src/integrationTest/resources/org/openstreetmap/atlas/generator/highwayFilter.json
@@ -1,0 +1,13 @@
+{
+    "global":
+    {
+        "scanUrls": ["org.openstreetmap.atlas"],
+        "filters":
+        {
+            "highwayFilter":
+            {
+                "taggableFilter": "highway->*"
+            }
+        }
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -82,14 +82,12 @@ public final class AtlasGeneratorParameters
             "shouldAlwaysSliceConfiguration",
             "The path to the configuration file that defines which entities on which country slicing will"
                     + " always be attempted regardless of the number of countries it intersects according to the"
-                    + " country boundary map's grid index.", StringConverter.IDENTITY,
-            Optionality.OPTIONAL);
+                    + " country boundary map's grid index.", StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<String> SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION = new Switch<>(
             "shouldIncludeFilteredOutputConfiguration",
             "The path to the configuration file that defines which will be included in filtered output."
                     + " Filtered output will only be generated if this switch is specified, and will be"
-                    + " stored in a separate subdirectory.", StringConverter.IDENTITY,
-            Optionality.OPTIONAL);
+                    + " stored in a separate subdirectory.", StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<Boolean> LINE_DELIMITED_GEOJSON_OUTPUT = new Switch<>(
             "lineDelimitedGeojsonOutput",
             "Output each shard as a line delimited geojson output file in the ldgeojson folder.",
@@ -105,19 +103,19 @@ public final class AtlasGeneratorParameters
     public static final Switch<Boolean> STATISTICS = new Switch<>("statistics",
             "Whether to run the shard statistics and country statistics", Boolean::parseBoolean,
             Optionality.OPTIONAL, "false");
-    
+
     public static ConfiguredFilter getConfiguredFilterFrom(final String name, final String path,
             final Map<String, String> configurationMap)
     {
         return getConfiguredFilterFrom(name, SparkJob.resource(path, configurationMap));
     }
-    
+
     public static ConfiguredFilter getConfiguredFilterFrom(final String name,
             final Resource configurationResource)
     {
         return ConfiguredFilter.from(name, getStandardConfigurationFrom(configurationResource));
     }
-    
+
     public static List<ConfiguredFilter> getConfiguredFilterListFrom(final StringList name,
             final Resource configurationResource)
     {
@@ -126,7 +124,7 @@ public final class AtlasGeneratorParameters
                 ConfiguredFilter.from(n, getStandardConfigurationFrom(configurationResource))));
         return filters;
     }
-    
+
     public static List<ConfiguredFilter> getConfiguredFilterListFrom(final StringList names,
             final StringList paths, final Map<String, String> configurationMap)
     {
@@ -149,52 +147,52 @@ public final class AtlasGeneratorParameters
         
         return filters;
     }
-    
+
     public static StandardConfiguration getStandardConfigurationFrom(final String path,
             final Map<String, String> configurationMap)
     {
         return getStandardConfigurationFrom(SparkJob.resource(path, configurationMap));
     }
-    
+
     public static StandardConfiguration getStandardConfigurationFrom(
             final Resource configurationResource)
     {
         return new StandardConfiguration(configurationResource);
     }
-    
+
     public static ConfiguredTaggableFilter getTaggableFilterFrom(final String path,
             final Map<String, String> configurationMap)
     {
         return getTaggableFilterFrom(SparkJob.resource(path, configurationMap));
     }
-    
+
     public static ConfiguredTaggableFilter getTaggableFilterFrom(
             final Resource configurationResource)
     {
         return new ConfiguredTaggableFilter(getStandardConfigurationFrom(configurationResource));
     }
-    
+
     public static boolean runStatistics(final CommandMap command)
     {
         return (boolean) command.get(STATISTICS);
     }
-    
+
     protected static AtlasLoadingOption buildAtlasLoadingOption(final CountryBoundaryMap boundaries,
             final Map<String, String> properties)
     {
-        final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption.createOptionWithAllEnabled(
-                boundaries);
+        final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption
+                .createOptionWithAllEnabled(boundaries);
         
         // Apply all configurations
         final String edgeConfiguration = properties.get(EDGE_CONFIGURATION.getName());
         if (edgeConfiguration != null)
         {
-            atlasLoadingOption.setEdgeFilter(
-                    getTaggableFilterFrom(new StringResource(edgeConfiguration)));
+            atlasLoadingOption
+                .setEdgeFilter(getTaggableFilterFrom(new StringResource(edgeConfiguration)));
         }
         
-        final String waySectioningConfiguration = properties.get(
-                WAY_SECTIONING_CONFIGURATION.getName());
+        final String waySectioningConfiguration = properties
+                .get(WAY_SECTIONING_CONFIGURATION.getName());
         if (waySectioningConfiguration != null)
         {
             atlasLoadingOption.setWaySectionFilter(
@@ -215,16 +213,16 @@ public final class AtlasGeneratorParameters
                     getTaggableFilterFrom(new StringResource(pbfWayConfiguration)));
         }
         
-        final String pbfRelationConfiguration = properties.get(
-                PBF_RELATION_CONFIGURATION.getName());
+        final String pbfRelationConfiguration = properties
+                .get(PBF_RELATION_CONFIGURATION.getName());
         if (pbfRelationConfiguration != null)
         {
             atlasLoadingOption.setOsmPbfRelationFilter(
                     getTaggableFilterFrom(new StringResource(pbfRelationConfiguration)));
         }
         
-        final String forceSlicingConfiguration = properties.get(
-                SHOULD_ALWAYS_SLICE_CONFIGURATION.getName());
+        final String forceSlicingConfiguration = properties
+                .get(SHOULD_ALWAYS_SLICE_CONFIGURATION.getName());
         if (forceSlicingConfiguration != null)
         {
             atlasLoadingOption.setRelationSlicingFilter(
@@ -240,7 +238,7 @@ public final class AtlasGeneratorParameters
         
         return atlasLoadingOption;
     }
-    
+
     protected static Map<String, String> extractAtlasLoadingProperties(final CommandMap command,
             final Map<String, String> sparkContext)
     {
@@ -249,39 +247,35 @@ public final class AtlasGeneratorParameters
         propertyMap.put(DATA_VERSION.getName(), (String) command.get(DATA_VERSION));
         
         final String edgeConfiguration = (String) command.get(EDGE_CONFIGURATION);
-        propertyMap.put(EDGE_CONFIGURATION.getName(), edgeConfiguration == null ?
-                null :
-                SparkJob.resource(edgeConfiguration, sparkContext).all());
-        
-        final String waySectioningConfiguration = (String) command.get(
-                WAY_SECTIONING_CONFIGURATION);
-        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null ?
-                null :
-                SparkJob.resource(waySectioningConfiguration, sparkContext).all());
+        propertyMap.put(EDGE_CONFIGURATION.getName(), edgeConfiguration == null ? null
+                : SparkJob.resource(edgeConfiguration, sparkContext).all());
+
+        final String waySectioningConfiguration = (String) command
+                .get(WAY_SECTIONING_CONFIGURATION);
+        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(),
+                waySectioningConfiguration == null ? null
+                        : SparkJob.resource(waySectioningConfiguration, sparkContext).all());
         
         final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
-        propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ?
-                null :
-                SparkJob.resource(pbfNodeConfiguration, sparkContext).all());
+        propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
+                : SparkJob.resource(pbfNodeConfiguration, sparkContext).all());
         
         final String pbfWayConfiguration = (String) command.get(PBF_WAY_CONFIGURATION);
-        propertyMap.put(PBF_WAY_CONFIGURATION.getName(), pbfWayConfiguration == null ?
-                null :
-                SparkJob.resource(pbfWayConfiguration, sparkContext).all());
+        propertyMap.put(PBF_WAY_CONFIGURATION.getName(), pbfWayConfiguration == null ? null
+                : SparkJob.resource(pbfWayConfiguration, sparkContext).all());
         
         final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
-        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null ?
-                null :
-                SparkJob.resource(pbfRelationConfiguration, sparkContext).all());
+        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
+                pbfRelationConfiguration == null ? null
+                        : SparkJob.resource(pbfRelationConfiguration, sparkContext).all());
         
         final String slicingConfiguration = (String) command.get(SLICING_CONFIGURATION);
-        propertyMap.put(SLICING_CONFIGURATION.getName(), slicingConfiguration == null ?
-                null :
-                SparkJob.resource(slicingConfiguration, sparkContext).all());
+        propertyMap.put(SLICING_CONFIGURATION.getName(), slicingConfiguration == null ? null
+                : SparkJob.resource(slicingConfiguration, sparkContext).all());
         
         return propertyMap;
     }
-    
+
     protected static SwitchList switches()
     {
         return new SwitchList().with(COUNTRIES, COUNTRY_SHAPES, SHARDING_TYPE, PBF_PATH, PBF_SCHEME,
@@ -293,7 +287,7 @@ public final class AtlasGeneratorParameters
                 PersistenceTools.COPY_SHARDING_AND_BOUNDARIES, CONFIGURED_FILTER_OUTPUT,
                 CONFIGURED_FILTER_NAME, STATISTICS);
     }
-    
+
     private AtlasGeneratorParameters()
     {
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -82,12 +82,14 @@ public final class AtlasGeneratorParameters
             "shouldAlwaysSliceConfiguration",
             "The path to the configuration file that defines which entities on which country slicing will"
                     + " always be attempted regardless of the number of countries it intersects according to the"
-                    + " country boundary map's grid index.", StringConverter.IDENTITY, Optionality.OPTIONAL);
+                    + " country boundary map's grid index.",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<String> SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION = new Switch<>(
             "shouldIncludeFilteredOutputConfiguration",
             "The path to the configuration file that defines which will be included in filtered output."
                     + " Filtered output will only be generated if this switch is specified, and will be"
-                    + " stored in a separate subdirectory.", StringConverter.IDENTITY, Optionality.OPTIONAL);
+                    + " stored in a separate subdirectory.",
+            StringConverter.IDENTITY, Optionality.OPTIONAL);
     public static final Switch<Boolean> LINE_DELIMITED_GEOJSON_OUTPUT = new Switch<>(
             "lineDelimitedGeojsonOutput",
             "Output each shard as a line delimited geojson output file in the ldgeojson folder.",
@@ -182,15 +184,15 @@ public final class AtlasGeneratorParameters
     {
         final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption
                 .createOptionWithAllEnabled(boundaries);
-        
+
         // Apply all configurations
         final String edgeConfiguration = properties.get(EDGE_CONFIGURATION.getName());
         if (edgeConfiguration != null)
         {
             atlasLoadingOption
-                .setEdgeFilter(getTaggableFilterFrom(new StringResource(edgeConfiguration)));
+                    .setEdgeFilter(getTaggableFilterFrom(new StringResource(edgeConfiguration)));
         }
-        
+
         final String waySectioningConfiguration = properties
                 .get(WAY_SECTIONING_CONFIGURATION.getName());
         if (waySectioningConfiguration != null)
@@ -198,21 +200,21 @@ public final class AtlasGeneratorParameters
             atlasLoadingOption.setWaySectionFilter(
                     getTaggableFilterFrom(new StringResource(waySectioningConfiguration)));
         }
-        
+
         final String pbfNodeConfiguration = properties.get(PBF_NODE_CONFIGURATION.getName());
         if (pbfNodeConfiguration != null)
         {
             atlasLoadingOption.setOsmPbfNodeFilter(
                     getTaggableFilterFrom(new StringResource(pbfNodeConfiguration)));
         }
-        
+
         final String pbfWayConfiguration = properties.get(PBF_WAY_CONFIGURATION.getName());
         if (pbfWayConfiguration != null)
         {
             atlasLoadingOption.setOsmPbfWayFilter(
                     getTaggableFilterFrom(new StringResource(pbfWayConfiguration)));
         }
-        
+
         final String pbfRelationConfiguration = properties
                 .get(PBF_RELATION_CONFIGURATION.getName());
         if (pbfRelationConfiguration != null)
@@ -220,7 +222,7 @@ public final class AtlasGeneratorParameters
             atlasLoadingOption.setOsmPbfRelationFilter(
                     getTaggableFilterFrom(new StringResource(pbfRelationConfiguration)));
         }
-        
+
         final String forceSlicingConfiguration = properties
                 .get(SHOULD_ALWAYS_SLICE_CONFIGURATION.getName());
         if (forceSlicingConfiguration != null)
@@ -228,14 +230,14 @@ public final class AtlasGeneratorParameters
             atlasLoadingOption.setRelationSlicingFilter(
                     getTaggableFilterFrom(new StringResource(forceSlicingConfiguration)));
         }
-        
+
         final String slicingConfiguration = properties.get(SLICING_CONFIGURATION.getName());
         if (slicingConfiguration != null)
         {
             atlasLoadingOption.setRelationSlicingFilter(
                     getTaggableFilterFrom(new StringResource(slicingConfiguration)));
         }
-        
+
         return atlasLoadingOption;
     }
 
@@ -245,7 +247,7 @@ public final class AtlasGeneratorParameters
         final Map<String, String> propertyMap = new HashMap<>();
         propertyMap.put(CODE_VERSION.getName(), (String) command.get(CODE_VERSION));
         propertyMap.put(DATA_VERSION.getName(), (String) command.get(DATA_VERSION));
-        
+
         final String edgeConfiguration = (String) command.get(EDGE_CONFIGURATION);
         propertyMap.put(EDGE_CONFIGURATION.getName(), edgeConfiguration == null ? null
                 : SparkJob.resource(edgeConfiguration, sparkContext).all());
@@ -255,24 +257,24 @@ public final class AtlasGeneratorParameters
         propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(),
                 waySectioningConfiguration == null ? null
                         : SparkJob.resource(waySectioningConfiguration, sparkContext).all());
-        
+
         final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
         propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
                 : SparkJob.resource(pbfNodeConfiguration, sparkContext).all());
-        
+
         final String pbfWayConfiguration = (String) command.get(PBF_WAY_CONFIGURATION);
         propertyMap.put(PBF_WAY_CONFIGURATION.getName(), pbfWayConfiguration == null ? null
                 : SparkJob.resource(pbfWayConfiguration, sparkContext).all());
-        
+
         final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
         propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
                 pbfRelationConfiguration == null ? null
                         : SparkJob.resource(pbfRelationConfiguration, sparkContext).all());
-        
+
         final String slicingConfiguration = (String) command.get(SLICING_CONFIGURATION);
         propertyMap.put(SLICING_CONFIGURATION.getName(), slicingConfiguration == null ? null
                 : SparkJob.resource(slicingConfiguration, sparkContext).all());
-        
+
         return propertyMap;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -1,6 +1,8 @@
 package org.openstreetmap.atlas.generator;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.openstreetmap.atlas.generator.persistence.AbstractMultipleAtlasBasedOutputFormat;
@@ -80,170 +82,206 @@ public final class AtlasGeneratorParameters
             "shouldAlwaysSliceConfiguration",
             "The path to the configuration file that defines which entities on which country slicing will"
                     + " always be attempted regardless of the number of countries it intersects according to the"
-                    + " country boundary map's grid index.",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
+                    + " country boundary map's grid index.", StringConverter.IDENTITY,
+            Optionality.OPTIONAL);
     public static final Switch<String> SHOULD_INCLUDE_FILTERED_OUTPUT_CONFIGURATION = new Switch<>(
             "shouldIncludeFilteredOutputConfiguration",
             "The path to the configuration file that defines which will be included in filtered output."
                     + " Filtered output will only be generated if this switch is specified, and will be"
-                    + " stored in a separate subdirectory.",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
+                    + " stored in a separate subdirectory.", StringConverter.IDENTITY,
+            Optionality.OPTIONAL);
     public static final Switch<Boolean> LINE_DELIMITED_GEOJSON_OUTPUT = new Switch<>(
             "lineDelimitedGeojsonOutput",
             "Output each shard as a line delimited geojson output file in the ldgeojson folder.",
             Boolean::parseBoolean, Optionality.OPTIONAL, "false");
     public static final Switch<String> SHARDING_TYPE = new Switch<>("sharding",
             "The sharding definition.", StringConverter.IDENTITY, Optionality.OPTIONAL);
-    public static final Switch<String> CONFIGURED_FILTER_OUTPUT = new Switch<>(
+    public static final Switch<StringList> CONFIGURED_FILTER_OUTPUT = new Switch<>(
             "configuredOutputFilter", "Path to configuration file for filtered output",
-            StringConverter.IDENTITY, Optionality.OPTIONAL);
-    public static final Switch<String> CONFIGURED_FILTER_NAME = new Switch<>("configuredFilterName",
-            "Name of the filter to be used for configured output", StringConverter.IDENTITY,
-            Optionality.OPTIONAL);
+            value -> StringList.split(value, ","), Optionality.OPTIONAL);
+    public static final Switch<StringList> CONFIGURED_FILTER_NAME = new Switch<>(
+            "configuredFilterName", "Name of the filter to be used for configured output",
+            value -> StringList.split(value, ","), Optionality.OPTIONAL);
     public static final Switch<Boolean> STATISTICS = new Switch<>("statistics",
             "Whether to run the shard statistics and country statistics", Boolean::parseBoolean,
             Optionality.OPTIONAL, "false");
-
+    
     public static ConfiguredFilter getConfiguredFilterFrom(final String name, final String path,
             final Map<String, String> configurationMap)
     {
         return getConfiguredFilterFrom(name, SparkJob.resource(path, configurationMap));
     }
-
+    
     public static ConfiguredFilter getConfiguredFilterFrom(final String name,
             final Resource configurationResource)
     {
         return ConfiguredFilter.from(name, getStandardConfigurationFrom(configurationResource));
     }
-
+    
+    public static List<ConfiguredFilter> getConfiguredFilterListFrom(final StringList name,
+            final Resource configurationResource)
+    {
+        final List<ConfiguredFilter> filters = new ArrayList<>();
+        name.forEach(n -> filters.add(
+                ConfiguredFilter.from(n, getStandardConfigurationFrom(configurationResource))));
+        return filters;
+    }
+    
+    public static List<ConfiguredFilter> getConfiguredFilterListFrom(final StringList names,
+            final StringList paths, final Map<String, String> configurationMap)
+    {
+        final List<ConfiguredFilter> filters = new ArrayList<>();
+        // loop through paths
+        for (final String path : paths)
+        {
+            // loop through filter names, check each path for filter with that name, if it exists
+            // add it to the list
+            for (final String name : names)
+            {
+                if (ConfiguredFilter.isPresent(name,
+                        getStandardConfigurationFrom(SparkJob.resource(path, configurationMap))))
+                {
+                    filters.add(getConfiguredFilterFrom(name,
+                            SparkJob.resource(path, configurationMap)));
+                }
+            }
+        }
+        
+        return filters;
+    }
+    
     public static StandardConfiguration getStandardConfigurationFrom(final String path,
             final Map<String, String> configurationMap)
     {
         return getStandardConfigurationFrom(SparkJob.resource(path, configurationMap));
     }
-
+    
     public static StandardConfiguration getStandardConfigurationFrom(
             final Resource configurationResource)
     {
         return new StandardConfiguration(configurationResource);
     }
-
+    
     public static ConfiguredTaggableFilter getTaggableFilterFrom(final String path,
             final Map<String, String> configurationMap)
     {
         return getTaggableFilterFrom(SparkJob.resource(path, configurationMap));
     }
-
+    
     public static ConfiguredTaggableFilter getTaggableFilterFrom(
             final Resource configurationResource)
     {
         return new ConfiguredTaggableFilter(getStandardConfigurationFrom(configurationResource));
     }
-
+    
     public static boolean runStatistics(final CommandMap command)
     {
         return (boolean) command.get(STATISTICS);
     }
-
+    
     protected static AtlasLoadingOption buildAtlasLoadingOption(final CountryBoundaryMap boundaries,
             final Map<String, String> properties)
     {
-        final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption
-                .createOptionWithAllEnabled(boundaries);
-
+        final AtlasLoadingOption atlasLoadingOption = AtlasLoadingOption.createOptionWithAllEnabled(
+                boundaries);
+        
         // Apply all configurations
         final String edgeConfiguration = properties.get(EDGE_CONFIGURATION.getName());
         if (edgeConfiguration != null)
         {
-            atlasLoadingOption
-                    .setEdgeFilter(getTaggableFilterFrom(new StringResource(edgeConfiguration)));
+            atlasLoadingOption.setEdgeFilter(
+                    getTaggableFilterFrom(new StringResource(edgeConfiguration)));
         }
-
-        final String waySectioningConfiguration = properties
-                .get(WAY_SECTIONING_CONFIGURATION.getName());
+        
+        final String waySectioningConfiguration = properties.get(
+                WAY_SECTIONING_CONFIGURATION.getName());
         if (waySectioningConfiguration != null)
         {
             atlasLoadingOption.setWaySectionFilter(
                     getTaggableFilterFrom(new StringResource(waySectioningConfiguration)));
         }
-
+        
         final String pbfNodeConfiguration = properties.get(PBF_NODE_CONFIGURATION.getName());
         if (pbfNodeConfiguration != null)
         {
             atlasLoadingOption.setOsmPbfNodeFilter(
                     getTaggableFilterFrom(new StringResource(pbfNodeConfiguration)));
         }
-
+        
         final String pbfWayConfiguration = properties.get(PBF_WAY_CONFIGURATION.getName());
         if (pbfWayConfiguration != null)
         {
             atlasLoadingOption.setOsmPbfWayFilter(
                     getTaggableFilterFrom(new StringResource(pbfWayConfiguration)));
         }
-
-        final String pbfRelationConfiguration = properties
-                .get(PBF_RELATION_CONFIGURATION.getName());
+        
+        final String pbfRelationConfiguration = properties.get(
+                PBF_RELATION_CONFIGURATION.getName());
         if (pbfRelationConfiguration != null)
         {
             atlasLoadingOption.setOsmPbfRelationFilter(
                     getTaggableFilterFrom(new StringResource(pbfRelationConfiguration)));
         }
-
-        final String forceSlicingConfiguration = properties
-                .get(SHOULD_ALWAYS_SLICE_CONFIGURATION.getName());
+        
+        final String forceSlicingConfiguration = properties.get(
+                SHOULD_ALWAYS_SLICE_CONFIGURATION.getName());
         if (forceSlicingConfiguration != null)
         {
             atlasLoadingOption.setRelationSlicingFilter(
                     getTaggableFilterFrom(new StringResource(forceSlicingConfiguration)));
         }
-
+        
         final String slicingConfiguration = properties.get(SLICING_CONFIGURATION.getName());
         if (slicingConfiguration != null)
         {
             atlasLoadingOption.setRelationSlicingFilter(
                     getTaggableFilterFrom(new StringResource(slicingConfiguration)));
         }
-
+        
         return atlasLoadingOption;
     }
-
+    
     protected static Map<String, String> extractAtlasLoadingProperties(final CommandMap command,
             final Map<String, String> sparkContext)
     {
         final Map<String, String> propertyMap = new HashMap<>();
         propertyMap.put(CODE_VERSION.getName(), (String) command.get(CODE_VERSION));
         propertyMap.put(DATA_VERSION.getName(), (String) command.get(DATA_VERSION));
-
+        
         final String edgeConfiguration = (String) command.get(EDGE_CONFIGURATION);
-        propertyMap.put(EDGE_CONFIGURATION.getName(), edgeConfiguration == null ? null
-                : SparkJob.resource(edgeConfiguration, sparkContext).all());
-
-        final String waySectioningConfiguration = (String) command
-                .get(WAY_SECTIONING_CONFIGURATION);
-        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(),
-                waySectioningConfiguration == null ? null
-                        : SparkJob.resource(waySectioningConfiguration, sparkContext).all());
-
+        propertyMap.put(EDGE_CONFIGURATION.getName(), edgeConfiguration == null ?
+                null :
+                SparkJob.resource(edgeConfiguration, sparkContext).all());
+        
+        final String waySectioningConfiguration = (String) command.get(
+                WAY_SECTIONING_CONFIGURATION);
+        propertyMap.put(WAY_SECTIONING_CONFIGURATION.getName(), waySectioningConfiguration == null ?
+                null :
+                SparkJob.resource(waySectioningConfiguration, sparkContext).all());
+        
         final String pbfNodeConfiguration = (String) command.get(PBF_NODE_CONFIGURATION);
-        propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ? null
-                : SparkJob.resource(pbfNodeConfiguration, sparkContext).all());
-
+        propertyMap.put(PBF_NODE_CONFIGURATION.getName(), pbfNodeConfiguration == null ?
+                null :
+                SparkJob.resource(pbfNodeConfiguration, sparkContext).all());
+        
         final String pbfWayConfiguration = (String) command.get(PBF_WAY_CONFIGURATION);
-        propertyMap.put(PBF_WAY_CONFIGURATION.getName(), pbfWayConfiguration == null ? null
-                : SparkJob.resource(pbfWayConfiguration, sparkContext).all());
-
+        propertyMap.put(PBF_WAY_CONFIGURATION.getName(), pbfWayConfiguration == null ?
+                null :
+                SparkJob.resource(pbfWayConfiguration, sparkContext).all());
+        
         final String pbfRelationConfiguration = (String) command.get(PBF_RELATION_CONFIGURATION);
-        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(),
-                pbfRelationConfiguration == null ? null
-                        : SparkJob.resource(pbfRelationConfiguration, sparkContext).all());
-
+        propertyMap.put(PBF_RELATION_CONFIGURATION.getName(), pbfRelationConfiguration == null ?
+                null :
+                SparkJob.resource(pbfRelationConfiguration, sparkContext).all());
+        
         final String slicingConfiguration = (String) command.get(SLICING_CONFIGURATION);
-        propertyMap.put(SLICING_CONFIGURATION.getName(), slicingConfiguration == null ? null
-                : SparkJob.resource(slicingConfiguration, sparkContext).all());
-
+        propertyMap.put(SLICING_CONFIGURATION.getName(), slicingConfiguration == null ?
+                null :
+                SparkJob.resource(slicingConfiguration, sparkContext).all());
+        
         return propertyMap;
     }
-
+    
     protected static SwitchList switches()
     {
         return new SwitchList().with(COUNTRIES, COUNTRY_SHAPES, SHARDING_TYPE, PBF_PATH, PBF_SCHEME,
@@ -255,7 +293,7 @@ public final class AtlasGeneratorParameters
                 PersistenceTools.COPY_SHARDING_AND_BOUNDARIES, CONFIGURED_FILTER_OUTPUT,
                 CONFIGURED_FILTER_NAME, STATISTICS);
     }
-
+    
     private AtlasGeneratorParameters()
     {
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorParameters.java
@@ -146,7 +146,7 @@ public final class AtlasGeneratorParameters
                 }
             }
         }
-        
+
         return filters;
     }
 


### PR DESCRIPTION
### Description:
This PR adds functionality to take in a list of configured output filters and filter names and save each filtered output in a directory under the configuredOutput. 

### Potential Impact:
Increases flexibility. No impact downstream.

### Unit Test Approach:
Add additional integration testing.

### Test Results:
Passed

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
