### PR TITLE
Split AtlasMissingShardVerifier query if too much response data

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.generator.sharding;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
@@ -58,6 +59,43 @@ public class AtlasMissingShardVerifier extends Command
     private static final Switch<String> WAY_FILTER = new Switch<>("wayFilter",
             "The json resource that defines what ways are ingested to atlas",
             StringConverter.IDENTITY, Optionality.OPTIONAL);
+    private static final Switch<Integer> RETRY_QUERY_COUNT = new Switch<>("numSplitQuery",
+            "The number of parts to split the query into if it fails", Integer::new,
+            Optionality.OPTIONAL, "2");
+
+    public static StringList createQueryList(final CountryBoundaryMap boundaries,
+            final Set<CountryShard> missingCountryShards, final int numQueries)
+    {
+        final StringList queries = new StringList();
+        int missingShardIndex = 0;
+        final int sectionSize = missingCountryShards.size() / numQueries;
+        final List<CountryShard> missingShardList = new ArrayList<>(missingCountryShards);
+        for (int i = 1; i <= numQueries; i++)
+        {
+            final StringBuilder query = new StringBuilder("(");
+            final int sectionUpperBound;
+            if (i == numQueries)
+            {
+                // if the sections don't divide cleanly, add the remainder to the last query
+                sectionUpperBound = missingCountryShards.size();
+            }
+            else
+            {
+                sectionUpperBound = missingShardIndex + sectionSize;
+            }
+            for (int j = missingShardIndex; j < sectionUpperBound; j++)
+            {
+                final CountryShard countryShard = missingShardList.get(j);
+                final Clip clip = intersectionClip(countryShard, boundaries);
+                final Rectangle clipBounds = clip.getClipMultiPolygon().bounds();
+                query.append(OverpassClient.buildCompactQuery("node", clipBounds));
+                missingShardIndex++;
+            }
+            query.append(");out body;");
+            queries.add(query);
+        }
+        return queries;
+    }
 
     public static void main(final String[] args)
     {
@@ -151,7 +189,8 @@ public class AtlasMissingShardVerifier extends Command
 
     public int verifier(final CountryBoundaryMap boundaries,
             final Set<CountryShard> missingCountryShardsUntrimmed, final File output,
-            final String server, final HttpHost proxy, final ConfiguredTaggableFilter filter)
+            final String server, final HttpHost proxy, final ConfiguredTaggableFilter filter,
+            final Integer numRetryQueries)
     {
         int returnCode = 0;
         final Set<CountryShard> missingCountryShards = removeShardsWithZeroIntersection(
@@ -164,10 +203,24 @@ public class AtlasMissingShardVerifier extends Command
             final List<OverpassOsmWay> ways = client.waysFromQuery(masterQuery);
             if (client.hasTooMuchResponseData())
             {
-                throw new CoreException(
-                        "The overpass query returned too much data. This means that there are "
-                                + "large amounts of data missing! Check the missing shard "
-                                + "list for outliers.");
+                logger.warn(
+                        "The overpass query returned too much data. This means that there's potentially"
+                                + "large amounts of data missing! Rerunning with smaller queries.");
+                client.resetTooMuchDataValue();
+                final StringList splitQueries = createQueryList(boundaries, missingCountryShards,
+                        numRetryQueries);
+                nodes.clear();
+                ways.clear();
+                for (final String query : splitQueries)
+                {
+                    nodes.addAll(client.nodesFromQuery(query));
+                    ways.addAll(client.waysFromQuery(query));
+                }
+            }
+            if (client.hasTooMuchResponseData())
+            {
+                throw new CoreException("The overpass query had to much data, even when split "
+                        + numRetryQueries + " times. There is lots of data missing!");
             }
             if (client.hasUnknownError())
             {
@@ -259,6 +312,7 @@ public class AtlasMissingShardVerifier extends Command
         }
         final String server = (String) command.get(OVERPASS_SERVER);
         final StringList proxySettings = (StringList) command.get(PROXY_SETTINGS);
+        final Integer numRetryQueries = (Integer) command.get(RETRY_QUERY_COUNT);
         HttpHost proxy = null;
         if (proxySettings != null)
         {
@@ -277,7 +331,7 @@ public class AtlasMissingShardVerifier extends Command
         try
         {
             returnCode = verifier(boundaries, missingCountryShards, output, server, proxy,
-                    wayFilter);
+                    wayFilter, numRetryQueries);
         }
         catch (final Exception e)
         {
@@ -291,6 +345,6 @@ public class AtlasMissingShardVerifier extends Command
     protected SwitchList switches()
     {
         return new SwitchList().with(BOUNDARIES, OUTPUT, MISSING_SHARDS, OVERPASS_SERVER,
-                PROXY_SETTINGS, WAY_FILTER);
+                PROXY_SETTINGS, WAY_FILTER, RETRY_QUERY_COUNT);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifier.java
@@ -206,7 +206,7 @@ public class AtlasMissingShardVerifier extends Command
                 logger.warn(
                         "The overpass query returned too much data. This means that there's potentially"
                                 + "large amounts of data missing! Rerunning with smaller queries.");
-                client.resetTooMuchDataValue();
+                client.resetTooMuchDataError();
                 final StringList splitQueries = createQueryList(boundaries, missingCountryShards,
                         numRetryQueries);
                 nodes.clear();

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
@@ -214,6 +214,11 @@ public class OverpassClient
         }
     }
 
+    public void resetTooMuchDataValue()
+    {
+        tooMuchResponseData = false;
+    }
+
     /**
      * Makes a way Overpass query, parses the response xml, and returns the ways that match the
      * query

--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/OverpassClient.java
@@ -214,7 +214,7 @@ public class OverpassClient
         }
     }
 
-    public void resetTooMuchDataValue()
+    public void resetTooMuchDataError()
     {
         tooMuchResponseData = false;
     }

--- a/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifierTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifierTest.java
@@ -1,0 +1,49 @@
+package org.openstreetmap.atlas.generator.sharding;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
+import org.openstreetmap.atlas.geography.sharding.CountryShard;
+import org.openstreetmap.atlas.utilities.collections.StringList;
+
+/**
+ * Test for AtlasMissingShardVerifier.
+ * 
+ * @author jamesgage
+ */
+public class AtlasMissingShardVerifierTest
+{
+    @Test
+    public void testCreateQueryList()
+    {
+        final CountryBoundaryMap boundaryMap = new CountryBoundaryMap();
+        final GeometryFactory geoFactory = new GeometryFactory();
+        final Coordinate point1 = new Coordinate(-64.544677734375, 35.3759765625);
+        final Coordinate point2 = new Coordinate(71.158447265625, 50.8447265625);
+        final Coordinate point3 = new Coordinate(71.158447265625, -27.9052734375);
+        final Coordinate point4 = new Coordinate(-60.325927734375, -31.4208984375);
+        final Coordinate[] coordinates = { point1, point2, point3, point4, point1 };
+        final Polygon boundary = geoFactory.createPolygon(coordinates);
+        boundaryMap.addCountry("WWW", boundary);
+        final Set<CountryShard> countryShards = new HashSet<>();
+        countryShards.add(new CountryShard("WWW", "1-0-0"));
+        countryShards.add(new CountryShard("WWW", "1-1-0"));
+        countryShards.add(new CountryShard("WWW", "1-0-1"));
+        countryShards.add(new CountryShard("WWW", "1-1-1"));
+        final StringList queries = AtlasMissingShardVerifier.createQueryList(boundaryMap,
+                countryShards, 3);
+        System.out.println(queries.get(0));
+        System.out.println(queries.get(1));
+        System.out.println(queries.get(2));
+        System.out.println(queries.size());
+        Assert.assertEquals("(node(0.0,-64.5446777,42.733401,0.0);<;);out body;", queries.get(0));
+        Assert.assertEquals("(node(0.0,0.0,50.8447266,71.1584473);<;);out body;", queries.get(1));
+        Assert.assertEquals(3, queries.size());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifierTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/sharding/AtlasMissingShardVerifierTest.java
@@ -38,10 +38,6 @@ public class AtlasMissingShardVerifierTest
         countryShards.add(new CountryShard("WWW", "1-1-1"));
         final StringList queries = AtlasMissingShardVerifier.createQueryList(boundaryMap,
                 countryShards, 3);
-        System.out.println(queries.get(0));
-        System.out.println(queries.get(1));
-        System.out.println(queries.get(2));
-        System.out.println(queries.size());
         Assert.assertEquals("(node(0.0,-64.5446777,42.733401,0.0);<;);out body;", queries.get(0));
         Assert.assertEquals("(node(0.0,0.0,50.8447266,71.1584473);<;);out body;", queries.get(1));
         Assert.assertEquals(3, queries.size());


### PR DESCRIPTION
### Description:

Split `AtlasMissingShardVerifier` master query into subqueries, if one query has too much data returned at once. This will allow accurate results on runs with large amounts of data missing.

### Potential Impact:

`AtlasMissingShardVerifier` can now handle runs with more missing data.

### Unit Test Approach:

Unit test for logic surrounding building the sub queries.

### Test Results:

Tests pass.

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
