### PR TITLE
AtlasGenerator to use ConfiguredFilter when possible

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '6.2.5-SNAPSHOT',
+    atlas: '6.2.5',
     spark: '2.4.4',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '6.2.2',
+    atlas: '6.2.5-SNAPSHOT',
     spark: '2.4.4',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',

--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -1,23 +1,16 @@
 package org.openstreetmap.atlas.generator;
 
-import java.io.IOException;
-
-import org.apache.hadoop.fs.Path;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
 import org.openstreetmap.atlas.generator.tools.spark.persistence.PersistenceTools;
 import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
-import org.openstreetmap.atlas.streaming.compression.Decompressor;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
-import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
-import org.openstreetmap.atlas.streaming.resource.Resource;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 
@@ -34,9 +27,34 @@ public class AtlasGeneratorIntegrationTest
     public static final String PBF_233 = PBF + "/9/9-168-233.osm.pbf";
     public static final String PBF_234 = PBF + "/9/9-168-234.osm.pbf";
     public static final String OUTPUT = "resource://test/output";
+
+    public static final String DMA_233 = "/DMA/9/DMA_9-168-233";
+    public static final String DMA_234 = "/DMA/9/DMA_9-168-234";
+    public static final String DMA_DDSQ = "/DMA/DMA_ddsq";
+    public static final String DMA_DDSR = "/DMA/DMA_ddsr";
+
     public static final String ATLAS_OUTPUT = "resource://test/atlas";
+    public static final String ATLAS_OUTPUT_233 = ATLAS_OUTPUT + DMA_233
+            + FileSuffix.ATLAS.toString();
+    public static final String ATLAS_OUTPUT_234 = ATLAS_OUTPUT + DMA_234
+            + FileSuffix.ATLAS.toString();
+    public static final String ATLAS_OUTPUT_DDSQ = ATLAS_OUTPUT + DMA_DDSQ
+            + FileSuffix.ATLAS.toString();
+    public static final String ATLAS_OUTPUT_DDSR = ATLAS_OUTPUT + DMA_DDSR
+            + FileSuffix.ATLAS.toString();
+
+    public static final String LDGEOJSON_GZ = ".ldgeojson.gz";
     public static final String LINE_DELIMITED_GEOJSON_OUTPUT = "resource://test/"
-            + AtlasGenerator.LINE_DELIMITED_GEOJSON_STATISTICS_FOLDER + "/DMA";
+            + AtlasGenerator.LINE_DELIMITED_GEOJSON_STATISTICS_FOLDER;
+    public static final String LINE_DELIMITED_GEOJSON_OUTPUT_233 = LINE_DELIMITED_GEOJSON_OUTPUT
+            + DMA_233 + LDGEOJSON_GZ;
+    public static final String LINE_DELIMITED_GEOJSON_OUTPUT_234 = LINE_DELIMITED_GEOJSON_OUTPUT
+            + DMA_234 + LDGEOJSON_GZ;
+    public static final String LINE_DELIMITED_GEOJSON_OUTPUT_DDSQ = LINE_DELIMITED_GEOJSON_OUTPUT
+            + DMA_DDSQ + LDGEOJSON_GZ;
+    public static final String LINE_DELIMITED_GEOJSON_OUTPUT_DDSR = LINE_DELIMITED_GEOJSON_OUTPUT
+            + DMA_DDSR + LDGEOJSON_GZ;
+
     public static final String COUNTRY_STATS = "resource://test/countryStats";
     public static final String SHARD_STATS = "resource://test/shardStats";
     public static final String CONFIGURED_OUTPUT_FILTER = "resource://test/filter/nothingFilter.json";
@@ -54,7 +72,23 @@ public class AtlasGeneratorIntegrationTest
     public static final String SLICING_CONFIGURATION = CONFIGURATION
             + "/atlas-relation-slicing.json";
 
-    private static final String CONFIGURED_OUTPUT = "resource://test/configuredOutput/";
+    public static final String CONFIGURED_OUTPUT = "resource://test/configuredOutput/";
+    public static final String CONFIGURED_OUTPUT_FILTER_NAME_233 = CONFIGURED_OUTPUT + FILTER_NAME
+            + DMA_233;
+    public static final String CONFIGURED_OUTPUT_FILTER_NAME_234 = CONFIGURED_OUTPUT + FILTER_NAME
+            + DMA_234;
+    public static final String CONFIGURED_OUTPUT_FILTER_NAME_2_233 = CONFIGURED_OUTPUT
+            + FILTER_NAME_2 + DMA_233;
+    public static final String CONFIGURED_OUTPUT_FILTER_NAME_2_234 = CONFIGURED_OUTPUT
+            + FILTER_NAME_2 + DMA_234;
+    public static final String CONFIGURED_OUTPUT_FILTER_NAME_DDSQ = CONFIGURED_OUTPUT + FILTER_NAME
+            + DMA_DDSQ;
+    public static final String CONFIGURED_OUTPUT_FILTER_NAME_DDSR = CONFIGURED_OUTPUT + FILTER_NAME
+            + DMA_DDSR;
+    public static final String CONFIGURED_OUTPUT_FILTER_NAME_2_DDSQ = CONFIGURED_OUTPUT
+            + FILTER_NAME_2 + DMA_DDSQ;
+    public static final String CONFIGURED_OUTPUT_FILTER_NAME_2_DDSR = CONFIGURED_OUTPUT
+            + FILTER_NAME_2 + DMA_DDSR;
 
     @After
     public void clean()
@@ -65,6 +99,7 @@ public class AtlasGeneratorIntegrationTest
     @Before
     public void setup()
     {
+        clean();
         ResourceFileSystem.registerResourceExtractionClass(AtlasGeneratorIntegrationTest.class);
         ResourceFileSystem.addResource(PBF_233, "DMA_cutout.osm.pbf");
         ResourceFileSystem.addResource(PBF_234, "DMA_cutout.osm.pbf");
@@ -134,56 +169,49 @@ public class AtlasGeneratorIntegrationTest
         ResourceFileSystem.printContents();
         dump();
 
-        try (ResourceFileSystem resourceFileSystem = new ResourceFileSystem())
-        {
-            Assert.assertTrue(resourceFileSystem
-                    .exists(new Path(ATLAS_OUTPUT + "/DMA/9/DMA_9-168-233.atlas")));
-            Assert.assertTrue(resourceFileSystem
-                    .exists(new Path(ATLAS_OUTPUT + "/DMA/9/DMA_9-168-234.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(
-                    new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-233.ldgeojson.gz")));
-            Assert.assertTrue(resourceFileSystem.exists(
-                    new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-234.ldgeojson.gz")));
-            Assert.assertEquals(402,
-                    Iterables.size(resourceForName(resourceFileSystem,
-                            LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-234.ldgeojson.gz")
-                                    .lines()));
-            Assert.assertEquals(336,
-                    Iterables.size(resourceForName(resourceFileSystem,
-                            LINE_DELIMITED_GEOJSON_OUTPUT + "/9/DMA_9-168-233.ldgeojson.gz")
-                                    .lines()));
+        Assert.assertTrue(ResourceFileSystem.getResource(ATLAS_OUTPUT_233).isPresent());
+        Assert.assertTrue(ResourceFileSystem.getResource(ATLAS_OUTPUT_234).isPresent());
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(LINE_DELIMITED_GEOJSON_OUTPUT_233).isPresent());
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(LINE_DELIMITED_GEOJSON_OUTPUT_234).isPresent());
+        Assert.assertEquals(402, Iterables.size(
+                ResourceFileSystem.getResourceOrElse(LINE_DELIMITED_GEOJSON_OUTPUT_234).lines()));
+        Assert.assertEquals(336, Iterables.size(
+                ResourceFileSystem.getResourceOrElse(LINE_DELIMITED_GEOJSON_OUTPUT_233).lines()));
 
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.SHARDING_FILE))));
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.SHARDING_META))));
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_FILE))));
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_META))));
+        Assert.assertTrue(ResourceFileSystem
+                .getResource(SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.SHARDING_FILE))
+                .isPresent());
+        Assert.assertTrue(ResourceFileSystem
+                .getResource(SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.SHARDING_META))
+                .isPresent());
+        Assert.assertTrue(ResourceFileSystem
+                .getResource(
+                        SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_FILE))
+                .isPresent());
+        Assert.assertTrue(ResourceFileSystem
+                .getResource(
+                        SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_META))
+                .isPresent());
 
-            Assert.assertTrue(resourceFileSystem.exists(
-                    new Path(CONFIGURED_OUTPUT + FILTER_NAME + "/DMA/9/DMA_9-168-233.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(
-                    new Path(CONFIGURED_OUTPUT + FILTER_NAME + "/DMA/9/DMA_9-168-234.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(
-                    new Path(CONFIGURED_OUTPUT + FILTER_NAME_2 + "/DMA/9/DMA_9-168-233.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(
-                    new Path(CONFIGURED_OUTPUT + FILTER_NAME_2 + "/DMA/9/DMA_9-168-234.atlas")));
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(CONFIGURED_OUTPUT_FILTER_NAME_233).isPresent());
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(CONFIGURED_OUTPUT_FILTER_NAME_234).isPresent());
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(CONFIGURED_OUTPUT_FILTER_NAME_2_233).isPresent());
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(CONFIGURED_OUTPUT_FILTER_NAME_2_234).isPresent());
 
-            final String countryStats = resourceForName(resourceFileSystem,
-                    COUNTRY_STATS + "/DMA.csv.gz").all();
-            final String shard933Stats = resourceForName(resourceFileSystem,
-                    SHARD_STATS + "/DMA/9/DMA_9-168-233.csv.gz").all();
-            final String shard934Stats = resourceForName(resourceFileSystem,
-                    SHARD_STATS + "/DMA/9/DMA_9-168-234.csv.gz").all();
-            Assert.assertNotEquals(countryStats, shard933Stats);
-            Assert.assertNotEquals(countryStats, shard934Stats);
-        }
-        catch (IllegalArgumentException | IOException e)
-        {
-            throw new CoreException("Unable to find output Atlas files.", e);
-        }
+        final String countryStats = ResourceFileSystem
+                .getResourceOrElse(COUNTRY_STATS + "/DMA.csv.gz").all();
+        final String shard933Stats = ResourceFileSystem
+                .getResourceOrElse(SHARD_STATS + "/DMA/9/DMA_9-168-233.csv.gz").all();
+        final String shard934Stats = ResourceFileSystem
+                .getResourceOrElse(SHARD_STATS + "/DMA/9/DMA_9-168-234.csv.gz").all();
+        Assert.assertNotEquals(countryStats, shard933Stats);
+        Assert.assertNotEquals(countryStats, shard934Stats);
     }
 
     @Test
@@ -219,43 +247,40 @@ public class AtlasGeneratorIntegrationTest
         ResourceFileSystem.printContents();
         dump();
 
-        try (ResourceFileSystem resourceFileSystem = new ResourceFileSystem())
-        {
-            Assert.assertTrue(
-                    resourceFileSystem.exists(new Path(ATLAS_OUTPUT + "/DMA/DMA_ddsq.atlas")));
-            Assert.assertTrue(
-                    resourceFileSystem.exists(new Path(ATLAS_OUTPUT + "/DMA/DMA_ddsr.atlas")));
-            Assert.assertTrue(resourceFileSystem
-                    .exists(new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/DMA_ddsq.ldgeojson.gz")));
-            Assert.assertTrue(resourceFileSystem
-                    .exists(new Path(LINE_DELIMITED_GEOJSON_OUTPUT + "/DMA_ddsr.ldgeojson.gz")));
-            Assert.assertEquals(700, Iterables.size(resourceForName(resourceFileSystem,
-                    LINE_DELIMITED_GEOJSON_OUTPUT + "/DMA_ddsq.ldgeojson.gz").lines()));
-            Assert.assertEquals(2, Iterables.size(resourceForName(resourceFileSystem,
-                    LINE_DELIMITED_GEOJSON_OUTPUT + "/DMA_ddsr.ldgeojson.gz").lines()));
+        Assert.assertTrue(ResourceFileSystem.getResource(ATLAS_OUTPUT_DDSQ).isPresent());
+        Assert.assertTrue(ResourceFileSystem.getResource(ATLAS_OUTPUT_DDSR).isPresent());
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(LINE_DELIMITED_GEOJSON_OUTPUT_DDSQ).isPresent());
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(LINE_DELIMITED_GEOJSON_OUTPUT_DDSR).isPresent());
+        Assert.assertEquals(700, Iterables.size(
+                ResourceFileSystem.getResourceOrElse(LINE_DELIMITED_GEOJSON_OUTPUT_DDSQ).lines()));
+        Assert.assertEquals(2, Iterables.size(
+                ResourceFileSystem.getResourceOrElse(LINE_DELIMITED_GEOJSON_OUTPUT_DDSR).lines()));
 
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.SHARDING_FILE))));
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.SHARDING_META))));
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_FILE))));
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_META))));
+        Assert.assertTrue(ResourceFileSystem
+                .getResource(SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.SHARDING_FILE))
+                .isPresent());
+        Assert.assertTrue(ResourceFileSystem
+                .getResource(SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.SHARDING_META))
+                .isPresent());
+        Assert.assertTrue(ResourceFileSystem
+                .getResource(
+                        SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_FILE))
+                .isPresent());
+        Assert.assertTrue(ResourceFileSystem
+                .getResource(
+                        SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_META))
+                .isPresent());
 
-            Assert.assertTrue(resourceFileSystem
-                    .exists(new Path(CONFIGURED_OUTPUT + FILTER_NAME + "/DMA/DMA_ddsq.atlas")));
-            Assert.assertTrue(resourceFileSystem
-                    .exists(new Path(CONFIGURED_OUTPUT + FILTER_NAME + "/DMA/DMA_ddsr.atlas")));
-            Assert.assertTrue(resourceFileSystem
-                    .exists(new Path(CONFIGURED_OUTPUT + FILTER_NAME_2 + "/DMA/DMA_ddsq.atlas")));
-            Assert.assertFalse(resourceFileSystem
-                    .exists(new Path(CONFIGURED_OUTPUT + FILTER_NAME_2 + "/DMA/DMA_ddsr.atlas")));
-        }
-        catch (IllegalArgumentException | IOException e)
-        {
-            throw new CoreException("Unable to find output Atlas files.", e);
-        }
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(CONFIGURED_OUTPUT_FILTER_NAME_DDSQ).isPresent());
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(CONFIGURED_OUTPUT_FILTER_NAME_DDSR).isPresent());
+        Assert.assertTrue(
+                ResourceFileSystem.getResource(CONFIGURED_OUTPUT_FILTER_NAME_2_DDSQ).isPresent());
+        Assert.assertFalse(
+                ResourceFileSystem.getResource(CONFIGURED_OUTPUT_FILTER_NAME_2_DDSR).isPresent());
     }
 
     void dump()
@@ -274,26 +299,5 @@ public class AtlasGeneratorIntegrationTest
             folder.mkdirs();
             ResourceFileSystem.dumpToDisk(folder);
         }
-    }
-
-    private Resource resourceForName(final ResourceFileSystem resourceFileSystem, final String name)
-    {
-        Decompressor decompressor = Decompressor.NONE;
-        if (name.endsWith(FileSuffix.GZIP.toString()))
-        {
-            decompressor = Decompressor.GZIP;
-        }
-        return new InputStreamResource(() ->
-        {
-            try
-            {
-                return resourceFileSystem.open(new Path(name));
-            }
-            catch (final Exception e)
-            {
-                throw new CoreException("Unable to open Resource {} in ResourceFileSystem", name,
-                        e);
-            }
-        }).withDecompressor(decompressor);
     }
 }

--- a/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
+++ b/src/integrationTest/java/org/openstreetmap/atlas/generator/AtlasGeneratorIntegrationTest.java
@@ -51,10 +51,10 @@ public class AtlasGeneratorIntegrationTest
     public static final String PBF_WAY_CONFIGURATION = CONFIGURATION + "/osm-pbf-way.json";
     public static final String PBF_RELATION_CONFIGURATION = CONFIGURATION
             + "/osm-pbf-relation.json";
-    public static final String SHOULD_ALWAYS_SLICE_CONFIGURATION = CONFIGURATION
-            + "/osm-pbf-relation.json";
     public static final String SLICING_CONFIGURATION = CONFIGURATION
             + "/atlas-relation-slicing.json";
+
+    private static final String CONFIGURED_OUTPUT = "resource://test/configuredOutput/";
 
     @After
     public void clean()
@@ -84,8 +84,6 @@ public class AtlasGeneratorIntegrationTest
                 AtlasLoadingOption.class);
         ResourceFileSystem.addResource(PBF_RELATION_CONFIGURATION, "osm-pbf-relation.json", false,
                 AtlasLoadingOption.class);
-        ResourceFileSystem.addResource(SHOULD_ALWAYS_SLICE_CONFIGURATION, "osm-pbf-relation.json",
-                false, AtlasLoadingOption.class);
         ResourceFileSystem.addResource(SLICING_CONFIGURATION, "atlas-relation-slicing.json", false,
                 AtlasLoadingOption.class);
     }
@@ -121,8 +119,6 @@ public class AtlasGeneratorIntegrationTest
                 + PBF_WAY_CONFIGURATION);
         arguments.add("-" + AtlasGeneratorParameters.PBF_RELATION_CONFIGURATION.getName() + "="
                 + PBF_RELATION_CONFIGURATION);
-        arguments.add("-" + AtlasGeneratorParameters.SHOULD_ALWAYS_SLICE_CONFIGURATION.getName()
-                + "=" + SHOULD_ALWAYS_SLICE_CONFIGURATION);
         arguments.add("-" + AtlasGeneratorParameters.SLICING_CONFIGURATION.getName() + "="
                 + SLICING_CONFIGURATION);
         arguments.add("-" + SparkJob.SPARK_OPTIONS.getName() + "=" + sparkConfiguration.join(","));
@@ -166,14 +162,14 @@ public class AtlasGeneratorIntegrationTest
             Assert.assertTrue(resourceFileSystem.exists(new Path(
                     SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_META))));
 
-            Assert.assertTrue(resourceFileSystem.exists(new Path("resource://test/configuredOutput/"
-                    + FILTER_NAME + "/DMA/9/DMA_9-168-233.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(new Path("resource://test/configuredOutput/"
-                    + FILTER_NAME + "/DMA/9/DMA_9-168-234.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(new Path("resource://test/configuredOutput/"
-                    + FILTER_NAME_2 + "/DMA/9/DMA_9-168-233.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(new Path("resource://test/configuredOutput/"
-                    + FILTER_NAME_2 + "/DMA/9/DMA_9-168-234.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(
+                    new Path(CONFIGURED_OUTPUT + FILTER_NAME + "/DMA/9/DMA_9-168-233.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(
+                    new Path(CONFIGURED_OUTPUT + FILTER_NAME + "/DMA/9/DMA_9-168-234.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(
+                    new Path(CONFIGURED_OUTPUT + FILTER_NAME_2 + "/DMA/9/DMA_9-168-233.atlas")));
+            Assert.assertTrue(resourceFileSystem.exists(
+                    new Path(CONFIGURED_OUTPUT + FILTER_NAME_2 + "/DMA/9/DMA_9-168-234.atlas")));
 
             final String countryStats = resourceForName(resourceFileSystem,
                     COUNTRY_STATS + "/DMA.csv.gz").all();
@@ -247,14 +243,14 @@ public class AtlasGeneratorIntegrationTest
             Assert.assertTrue(resourceFileSystem.exists(new Path(
                     SparkFileHelper.combine(ATLAS_OUTPUT, PersistenceTools.BOUNDARIES_META))));
 
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    "resource://test/configuredOutput/" + FILTER_NAME + "/DMA/DMA_ddsq.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    "resource://test/configuredOutput/" + FILTER_NAME + "/DMA/DMA_ddsr.atlas")));
-            Assert.assertTrue(resourceFileSystem.exists(new Path(
-                    "resource://test/configuredOutput/" + FILTER_NAME_2 + "/DMA/DMA_ddsq.atlas")));
-            Assert.assertFalse(resourceFileSystem.exists(new Path(
-                    "resource://test/configuredOutput/" + FILTER_NAME_2 + "/DMA/DMA_ddsr.atlas")));
+            Assert.assertTrue(resourceFileSystem
+                    .exists(new Path(CONFIGURED_OUTPUT + FILTER_NAME + "/DMA/DMA_ddsq.atlas")));
+            Assert.assertTrue(resourceFileSystem
+                    .exists(new Path(CONFIGURED_OUTPUT + FILTER_NAME + "/DMA/DMA_ddsr.atlas")));
+            Assert.assertTrue(resourceFileSystem
+                    .exists(new Path(CONFIGURED_OUTPUT + FILTER_NAME_2 + "/DMA/DMA_ddsq.atlas")));
+            Assert.assertFalse(resourceFileSystem
+                    .exists(new Path(CONFIGURED_OUTPUT + FILTER_NAME_2 + "/DMA/DMA_ddsr.atlas")));
         }
         catch (IllegalArgumentException | IOException e)
         {

--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -27,6 +27,7 @@ import org.openstreetmap.atlas.geography.atlas.change.Change;
 import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
 import org.openstreetmap.atlas.geography.atlas.change.description.ChangeDescriptorType;
 import org.openstreetmap.atlas.geography.atlas.change.diff.AtlasDiff;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
@@ -40,7 +41,6 @@ import org.openstreetmap.atlas.geography.sharding.CountryShard;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.Resource;
-import org.openstreetmap.atlas.tags.Taggable;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.configuration.ConfiguredFilter;
@@ -541,7 +541,7 @@ public final class AtlasGeneratorHelper implements Serializable
     }
 
     protected static PairFunction<Tuple2<String, Atlas>, String, Atlas> subatlas(
-            final Predicate<Taggable> filter, final AtlasCutType cutType)
+            final Predicate<AtlasEntity> filter, final AtlasCutType cutType)
     {
         return (Serializable & PairFunction<Tuple2<String, Atlas>, String, Atlas>) tuple ->
         {
@@ -556,8 +556,7 @@ public final class AtlasGeneratorHelper implements Serializable
             try
             {
                 // Slice the Atlas
-                final Optional<Atlas> subAtlasOptional = originalAtlas.subAtlas(filter::test,
-                        cutType);
+                final Optional<Atlas> subAtlasOptional = originalAtlas.subAtlas(filter, cutType);
                 if (subAtlasOptional.isPresent())
                 {
                     subAtlas = subAtlasOptional.get();

--- a/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/world/WorldAtlasGenerator.java
@@ -9,6 +9,7 @@ import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.AtlasMetaData;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
+import org.openstreetmap.atlas.geography.atlas.pbf.BridgeConfiguredFilter;
 import org.openstreetmap.atlas.geography.atlas.raw.creation.RawAtlasGenerator;
 import org.openstreetmap.atlas.geography.atlas.raw.sectioning.WaySectionProcessor;
 import org.openstreetmap.atlas.geography.atlas.raw.slicing.RawAtlasSlicer;
@@ -39,13 +40,6 @@ import org.slf4j.LoggerFactory;
 public class WorldAtlasGenerator extends Command
 {
     private static final Logger logger = LoggerFactory.getLogger(WorldAtlasGenerator.class);
-
-    private static final Switch<Resource> PBF = new Switch<>("pbf",
-            "The pbf file or folder containing the OSM pbfs", value -> openResource(value),
-            Optionality.REQUIRED);
-    private static final Switch<WritableResource> ATLAS = new Switch<>("atlas",
-            "The atlas file to which the Atlas will be saved", value -> openWritableResource(value),
-            Optionality.REQUIRED);
     private static final Switch<File> STATISTICS = new Switch<>("statistics",
             "The file that will contain the statistics", File::new, Optionality.OPTIONAL);
     // the default boundary is a bounding box of the world
@@ -81,6 +75,12 @@ public class WorldAtlasGenerator extends Command
             new StandardConfiguration(new StringResource("{\"filters\": []}")));
     private static Map<String, String> configuration = Maps.hashMap("fs.file.impl",
             LocalFileSystem.class.getName());
+    private static final Switch<Resource> PBF = new Switch<>("pbf",
+            "The pbf file or folder containing the OSM pbfs", WorldAtlasGenerator::openResource,
+            Optionality.REQUIRED);
+    private static final Switch<WritableResource> ATLAS = new Switch<>("atlas",
+            "The atlas file to which the Atlas will be saved",
+            WorldAtlasGenerator::openWritableResource, Optionality.REQUIRED);
 
     public static void main(final String[] args)
     {
@@ -131,7 +131,8 @@ public class WorldAtlasGenerator extends Command
         if (edgeConfiguration != null)
         {
             loadingOptions.setEdgeFilter(
-                    new ConfiguredTaggableFilter(new StandardConfiguration(edgeConfiguration)));
+                    new BridgeConfiguredFilter("", AtlasLoadingOption.ATLAS_EDGE_FILTER_NAME,
+                            new StandardConfiguration(edgeConfiguration)));
         }
 
         if (pbfWayConfiguration == null)

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -217,9 +217,4 @@ public class HadoopAtlasFileCacheTest
             parent.deleteRecursively();
         }
     }
-
-    private void assertEquals()
-    {
-
-    }
 }

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Optional;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceSchemeType;
@@ -15,7 +14,6 @@ import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
 import org.openstreetmap.atlas.geography.sharding.SlippyTile;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.Resource;
-import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.utilities.collections.Maps;
 
 /**
@@ -39,14 +37,10 @@ public class HadoopAtlasFileCacheTest
             final PackedAtlasBuilder builder1 = new PackedAtlasBuilder();
             builder1.addPoint(1L, Location.CENTER, Maps.hashMap());
             final PackedAtlas atlas1 = (PackedAtlas) builder1.get();
-            final StringResource string1 = new StringResource();
-            atlas1.save(string1);
 
             final PackedAtlasBuilder builder2 = new PackedAtlasBuilder();
             builder2.addPoint(2L, Location.CENTER, Maps.hashMap());
             final PackedAtlas atlas2 = (PackedAtlas) builder2.get();
-            final StringResource string2 = new StringResource();
-            atlas2.save(string2);
 
             final File atlasFile1 = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
             atlas1.save(atlasFile1);
@@ -57,15 +51,15 @@ public class HadoopAtlasFileCacheTest
             final Resource resource1 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();
             final Resource resource2 = cache.get("AAA", new SlippyTile(2, 2, 2)).get();
 
-            Assert.assertEquals(string1.all(), resource1.all());
-            Assert.assertEquals(string2.all(), resource2.all());
+            Assert.assertEquals(atlas1, PackedAtlas.load(resource1));
+            Assert.assertEquals(atlas2, PackedAtlas.load(resource2));
 
             // cache hit, using cached copy
             final Resource resource3 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();
             final Resource resource4 = cache.get("AAA", new SlippyTile(2, 2, 2)).get();
 
-            Assert.assertEquals(string1.all(), resource3.all());
-            Assert.assertEquals(string2.all(), resource4.all());
+            Assert.assertEquals(atlas1, PackedAtlas.load(resource3));
+            Assert.assertEquals(atlas2, PackedAtlas.load(resource4));
         }
         finally
         {
@@ -93,14 +87,10 @@ public class HadoopAtlasFileCacheTest
             final PackedAtlasBuilder builder1 = new PackedAtlasBuilder();
             builder1.addPoint(1L, Location.CENTER, Maps.hashMap());
             final PackedAtlas atlas1 = (PackedAtlas) builder1.get();
-            final StringResource string1 = new StringResource();
-            atlas1.save(string1);
 
             final PackedAtlasBuilder builder2 = new PackedAtlasBuilder();
             builder2.addPoint(2L, Location.CENTER, Maps.hashMap());
             final PackedAtlas atlas2 = (PackedAtlas) builder2.get();
-            final StringResource string2 = new StringResource();
-            atlas2.save(string2);
 
             final File atlasFile1 = parentAtlasCountry.child("1/AAA_1-1-1.atlas");
             atlas1.save(atlasFile1);
@@ -111,15 +101,15 @@ public class HadoopAtlasFileCacheTest
             final Resource resource1 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();
             final Resource resource2 = cache.get("AAA", new SlippyTile(2, 2, 2)).get();
 
-            Assert.assertEquals(string1.all(), resource1.all());
-            Assert.assertEquals(string2.all(), resource2.all());
+            Assert.assertEquals(atlas1, PackedAtlas.load(resource1));
+            Assert.assertEquals(atlas2, PackedAtlas.load(resource2));
 
             // cache hit, using cached copy
             final Resource resource3 = cache.get("AAA", new SlippyTile(1, 1, 1)).get();
             final Resource resource4 = cache.get("AAA", new SlippyTile(2, 2, 2)).get();
 
-            Assert.assertEquals(string1.all(), resource3.all());
-            Assert.assertEquals(string2.all(), resource4.all());
+            Assert.assertEquals(atlas1, PackedAtlas.load(resource3));
+            Assert.assertEquals(atlas2, PackedAtlas.load(resource4));
         }
         finally
         {
@@ -128,11 +118,7 @@ public class HadoopAtlasFileCacheTest
         }
     }
 
-    /**
-     * This test is non-deterministic, we need to find out why and re-enable.
-     */
     @Test
-    @Ignore
     public void testCachesWithDifferentNamespaces()
     {
         final File parent = File.temporaryFolder();
@@ -174,14 +160,14 @@ public class HadoopAtlasFileCacheTest
             final Resource resource2 = cache2.get("AAA", new SlippyTile(1, 1, 1)).get();
 
             // the files should be unequal, even though the URIs are the same
-            Assert.assertNotEquals(resource1.all(), resource2.all());
+            Assert.assertNotEquals(PackedAtlas.load(resource1), PackedAtlas.load(resource2));
 
             // now we are getting the cached versions of the file
             final Resource resource3 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();
             final Resource resource4 = cache2.get("AAA", new SlippyTile(1, 1, 1)).get();
 
             // the files should still be unequal, even though the URIs are the same
-            Assert.assertNotEquals(resource3.all(), resource4.all());
+            Assert.assertNotEquals(PackedAtlas.load(resource3), PackedAtlas.load(resource4));
 
             // delete cache1's cached version of the file
             cache1.invalidate("AAA", new SlippyTile(1, 1, 1));
@@ -195,7 +181,7 @@ public class HadoopAtlasFileCacheTest
             final Resource resource5 = cache1.get("AAA", new SlippyTile(1, 1, 1)).get();
 
             // now the resources should be identical
-            Assert.assertEquals(resource4.all(), resource5.all());
+            Assert.assertEquals(PackedAtlas.load(resource4), PackedAtlas.load(resource5));
         }
         finally
         {
@@ -230,5 +216,10 @@ public class HadoopAtlasFileCacheTest
             cache.invalidate();
             parent.deleteRecursively();
         }
+    }
+
+    private void assertEquals()
+    {
+
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/caching/HadoopAtlasFileCacheTest.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Optional;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceScheme;
 import org.openstreetmap.atlas.generator.persistence.scheme.SlippyTilePersistenceSchemeType;
@@ -23,15 +24,7 @@ import org.openstreetmap.atlas.utilities.collections.Maps;
 public class HadoopAtlasFileCacheTest
 {
     @Test
-    public void testSequentially()
-    {
-        testCache();
-        testCacheWithFetcher();
-        testCachesWithDifferentNamespaces();
-        testNonexistentResource();
-    }
-
-    private void testCache()
+    public void testCache()
     {
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");
@@ -81,7 +74,8 @@ public class HadoopAtlasFileCacheTest
         }
     }
 
-    private void testCacheWithFetcher()
+    @Test
+    public void testCacheWithFetcher()
     {
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");
@@ -134,7 +128,12 @@ public class HadoopAtlasFileCacheTest
         }
     }
 
-    private void testCachesWithDifferentNamespaces()
+    /**
+     * This test is non-deterministic, we need to find out why and re-enable.
+     */
+    @Test
+    @Ignore
+    public void testCachesWithDifferentNamespaces()
     {
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");
@@ -206,7 +205,8 @@ public class HadoopAtlasFileCacheTest
         }
     }
 
-    private void testNonexistentResource()
+    @Test
+    public void testNonexistentResource()
     {
         final File parent = File.temporaryFolder();
         final File parentAtlas = new File(parent + "/atlas");


### PR DESCRIPTION
### Description:

Now that `ConfiguredFilter` is accepted by `AtlasLoadingOption` (after https://github.com/osmlab/atlas/pull/660 and https://github.com/osmlab/atlas/pull/662) this update makes AtlasGenerator accept `ConfiguredFilter` filters for all non-pbf filtering needs.

Also:
- Remove remnants of `SHOULD_ALWAYS_SLICE_CONFIGURATION` the logic of which had been removed a few versions ago.

### Potential Impact:

More options for configuring the job, including the option to choose geometrical areas where the OSM Ways become `Edge`s for example. It is also backwards compatible, so the previously used `ConfiguredTaggableFilter` filter arrays like [this one](https://github.com/osmlab/atlas/blob/6.2.3/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-edge.json) will still work. For reference [here is the same file](https://github.com/osmlab/atlas/blob/6.2.5/src/main/resources/org/openstreetmap/atlas/geography/atlas/pbf/atlas-edge.json) updated to use `ConfiguredFilter`.

### Unit Test Approach:

Updated integration tests

### Test Results:

Pass

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
