### PR TITLE
Update dependencies to use Spark 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,6 @@ repositories
 
 configurations
 {
-    all {
-        resolutionStrategy {
-            // Force jackson 2.6.7 for Spark
-            force 'com.fasterxml.jackson.core:jackson-core:2.6.7', 'com.fasterxml.jackson.core:jackson-databind:2.6.7', 'com.fasterxml.jackson.core:jackson-annotations:2.6.7'
-        }
-    }
     compile
     {
         resolutionStrategy

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,7 +10,7 @@ project.ext.versions = [
 project.ext.packages = [
     atlas: "org.openstreetmap.atlas:atlas:${versions.atlas}",
     spark:[
-        core: "org.apache.spark:spark-core_2.11:${versions.spark}",
+        core: "org.apache.spark:spark-core_2.12:${versions.spark}",
     ],
     snappy: "org.xerial.snappy:snappy-java:${versions.snappy}",
     checkstyle: "com.puppycrawl.tools:checkstyle:${versions.checkstyle}",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,8 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '6.2.9',
-    spark: '2.4.4',
+    atlas: '6.2.10',
+    spark: '3.0.1',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',
 ]


### PR DESCRIPTION
### Description:

Now make atlas-generator target Spark 3+

### Potential Impact:

Limited, though support for Spark 3 will now be required.

### Unit Test Approach:

### Test Results:

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
