### PR TITLE
Spark FileSystems should be closed when no longer needed.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/AtlasGeneratorHelper.java
@@ -308,16 +308,13 @@ public final class AtlasGeneratorHelper implements Serializable
                     .buildAtlasLoadingOption(boundaries.getValue(), loadingOptions.getValue());
             atlasLoadingOption.setCountryCode(countryName);
 
-            // Build the PbfLoader
-            final PbfLoader loader = new PbfLoader(pbfContext, sparkContext, boundaries.getValue(),
+            // Build the PbfLoader and generate the raw Atlas for this shard
+            final Atlas atlas;
+            try (PbfLoader loader = new PbfLoader(pbfContext, sparkContext, boundaries.getValue(),
                     atlasLoadingOption,
                     loadingOptions.getValue().get(AtlasGeneratorParameters.CODE_VERSION.getName()),
                     loadingOptions.getValue().get(AtlasGeneratorParameters.DATA_VERSION.getName()),
-                    task.getAllShards());
-
-            // Generate the raw Atlas for this shard
-            final Atlas atlas;
-            try
+                    task.getAllShards()))
             {
                 atlas = loader.generateRawAtlas(countryName, shard);
             }

--- a/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.generator;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author matthieun
  */
-public class PbfLoader implements Serializable
+public class PbfLoader implements AutoCloseable, Serializable
 {
     private static final long serialVersionUID = -3991330796225288845L;
 
@@ -82,6 +83,12 @@ public class PbfLoader implements Serializable
         this.codeVersion = codeVersion;
         this.dataVersion = dataVersion;
         this.countryShards = countryShards;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        this.locator.close();
     }
 
     public Atlas generateRawAtlas(final String countryName, final Shard shard)

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemCreator.java
@@ -63,9 +63,9 @@ public class FileSystemCreator
     public FileSystem get(final String path, final Map<String, String> configuration)
     {
         final Configuration conf = new Configuration();
-        for (final String key : configuration.keySet())
+        for (final Map.Entry<String, String> entry : configuration.entrySet())
         {
-            conf.set(key, configuration.get(key));
+            conf.set(entry.getKey(), entry.getValue());
         }
         return get(path, conf);
     }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemHelper.java
@@ -285,24 +285,19 @@ public final class FileSystemHelper
     {
         try (FileSystem fileSystem = new FileSystemCreator().get(directory, configuration))
         {
-
-            final FileStatus[] fileStatusList;
-            try
-            {
-                fileStatusList = filter == null ? fileSystem.listStatus(new Path(directory))
-                        : fileSystem.listStatus(new Path(directory), filter);
-            }
-            catch (final Exception e)
-            {
-                throw new CoreException("Could not locate files on directory {}", directory, e);
-            }
-
+            final FileStatus[] fileStatusList = filter == null
+                    ? fileSystem.listStatus(new Path(directory))
+                    : fileSystem.listStatus(new Path(directory), filter);
             return Stream.of(fileStatusList).map(FileStatus::getPath)
                     .map(path -> getResource(fileSystem, path)).collect(Collectors.toList());
         }
         catch (final IOException e)
         {
             logger.error(FILESYSTEM_NOT_CLOSED, e);
+        }
+        catch (final Exception e)
+        {
+            throw new CoreException("Could not locate files on directory {}", directory, e);
         }
 
         return Collections.emptyList();

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/rdd/ShardedAtlasRDDLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/rdd/ShardedAtlasRDDLoader.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
@@ -99,10 +100,9 @@ public class ShardedAtlasRDDLoader
         final String atlasPath = atlasPath(atlasDirectory, country, shardName);
         logger.info("Start to load atlas from atlas directory: {} ", atlasPath);
         Atlas atlas = null;
-        try
+        try (FileSystem fileSystem = new FileSystemCreator().get(atlasPath, configurationMap))
         {
-            if (!new FileSystemCreator().get(atlasPath, configurationMap)
-                    .exists(new Path(atlasPath)))
+            if (!fileSystem.exists(new Path(atlasPath)))
             {
                 logger.warn("No atlas found for path {}", atlasPath);
                 return atlas;

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java
@@ -462,9 +462,8 @@ public class SparkFileHelper implements Serializable
      */
     public boolean exists(final String path)
     {
-        try
+        try (FileSystem fileSystem = new FileSystemCreator().get(path, this.sparkContext))
         {
-            final FileSystem fileSystem = new FileSystemCreator().get(path, this.sparkContext);
             return fileSystem.exists(new Path(path));
         }
         catch (final Exception e)
@@ -481,9 +480,8 @@ public class SparkFileHelper implements Serializable
      */
     public boolean isDirectory(final String path)
     {
-        try
+        try (FileSystem fileSystem = new FileSystemCreator().get(path, this.sparkContext))
         {
-            final FileSystem fileSystem = new FileSystemCreator().get(path, this.sparkContext);
             return fileSystem.isDirectory(new Path(path));
         }
         catch (final Exception e)

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSFile.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSFile.java
@@ -22,7 +22,7 @@ import org.openstreetmap.atlas.utilities.scalars.Duration;
  * @author cuthbertm
  * @author sbhalekar
  */
-public class HDFSFile extends AbstractWritableResource
+public class HDFSFile extends AbstractWritableResource implements AutoCloseable
 {
     private static final int DEFAULT_RETRIES = 3;
     private static final Duration DEFAULT_RETRYWAIT = Duration.seconds(2);
@@ -74,6 +74,12 @@ public class HDFSFile extends AbstractWritableResource
             final Configuration configuration) throws URISyntaxException, IOException
     {
         this(new Path(String.format(HDFS_PATH_FORMAT, server, port, path)), configuration);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        this.system.close();
     }
 
     public boolean exists()

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalker.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalker.java
@@ -16,6 +16,8 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.openstreetmap.atlas.exception.CoreException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.AbstractIterator;
 
@@ -31,6 +33,8 @@ import com.google.common.collect.AbstractIterator;
  */
 public final class HDFSWalker
 {
+    private static final Logger logger = LoggerFactory.getLogger(HDFSWalker.class);
+
     /**
      * Collection of hadoop file status object and it's corresponding depth in the filesystem
      * hierarchy
@@ -213,7 +217,7 @@ public final class HDFSWalker
         }
         catch (final IOException e)
         {
-            // TODO add a logger or throw?
+            logger.error("HDFSIterator not closed properly", e);
         }
         return Stream.empty();
     }

--- a/src/test/java/org/openstreetmap/atlas/generator/PbfLocatorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/PbfLocatorTest.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.generator;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
@@ -44,7 +45,7 @@ public class PbfLocatorTest
     }
 
     @Test
-    public void testDefaultTileFinder()
+    public void testDefaultTileFinder() throws IOException
     {
         // Test a default scheme
         final SlippyTilePersistenceScheme scheme = new SlippyTilePersistenceScheme(
@@ -52,17 +53,19 @@ public class PbfLocatorTest
         logger.warn("{}", scheme.getScheme());
         final PbfContext pbfContext = new PbfContext("resource://" + version,
                 new SlippyTileSharding(10), scheme);
-        final PbfLocator locator = new PbfLocator(pbfContext,
-                ResourceFileSystem.simpleconfiguration());
-        final Polygon outer = Rectangle.forCorners(Location.forString("24.953302,-77.608195"),
-                Location.forString("25.131896,-77.207033"));
-        final MultiPolygon multiPolygon = MultiPolygon.forPolygon(outer);
-        final List<LocatedPbf> tiles = Iterables.asList(locator.pbfsCovering(multiPolygon));
-        Assert.assertEquals(2, tiles.size());
+        try (PbfLocator locator = new PbfLocator(pbfContext,
+                ResourceFileSystem.simpleconfiguration()))
+        {
+            final Polygon outer = Rectangle.forCorners(Location.forString("24.953302,-77.608195"),
+                    Location.forString("25.131896,-77.207033"));
+            final MultiPolygon multiPolygon = MultiPolygon.forPolygon(outer);
+            final List<LocatedPbf> tiles = Iterables.asList(locator.pbfsCovering(multiPolygon));
+            Assert.assertEquals(2, tiles.size());
+        }
     }
 
     @Test
-    public void testDifferentTileFinder()
+    public void testDifferentTileFinder() throws IOException
     {
         // Test a non-default scheme
         final SlippyTilePersistenceScheme scheme = new SlippyTilePersistenceScheme(
@@ -70,13 +73,15 @@ public class PbfLocatorTest
         logger.warn("{}", scheme.getScheme());
         final PbfContext pbfContext = new PbfContext("resource://" + version,
                 new SlippyTileSharding(10), scheme);
-        final PbfLocator locator = new PbfLocator(pbfContext,
-                ResourceFileSystem.simpleconfiguration());
-        final Polygon outer = Rectangle.forCorners(Location.forString("24.953302,-77.608195"),
-                Location.forString("25.131896,-77.207033"));
-        final MultiPolygon multiPolygon = MultiPolygon.forPolygon(outer);
-        final List<LocatedPbf> tiles = Iterables.asList(locator.pbfsCovering(multiPolygon));
-        Assert.assertEquals(2, tiles.size());
+        try (PbfLocator locator = new PbfLocator(pbfContext,
+                ResourceFileSystem.simpleconfiguration()))
+        {
+            final Polygon outer = Rectangle.forCorners(Location.forString("24.953302,-77.608195"),
+                    Location.forString("25.131896,-77.207033"));
+            final MultiPolygon multiPolygon = MultiPolygon.forPolygon(outer);
+            final List<LocatedPbf> tiles = Iterables.asList(locator.pbfsCovering(multiPolygon));
+            Assert.assertEquals(2, tiles.size());
+        }
     }
 
     private void uploadFile(final String name)

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSFileTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSFileTest.java
@@ -1,0 +1,185 @@
+package org.openstreetmap.atlas.generator.tools.streaming.resource;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openstreetmap.atlas.exception.CoreException;
+
+/**
+ * Test class for {@link HDFSFile}
+ *
+ * @author Taylor Smock
+ */
+public class HDFSFileTest
+{
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testDirectory() throws IOException
+    {
+        final File tempFile = this.temporaryFolder.newFile();
+        final HDFSFile file = new HDFSFile(tempFile.getPath());
+        assertFalse(file.isDirectory());
+        assertTrue(tempFile.delete());
+        assertTrue(tempFile.mkdir());
+        assertTrue(file.isDirectory());
+    }
+
+    @Test
+    public void testFileExists() throws IOException
+    {
+        final File temp = this.temporaryFolder.newFile();
+        final HDFSFile file = new HDFSFile(temp.getPath());
+        assertTrue(file.exists());
+        assertTrue(temp.delete());
+        assertFalse(file.exists());
+    }
+
+    @Test
+    public void testLength() throws IOException
+    {
+        final File temp = this.temporaryFolder.newFile();
+        final HDFSFile file = new HDFSFile(temp.getPath());
+        file.setRetries(0);
+        try (OutputStream outputStream = file.onWrite())
+        {
+            outputStream.write(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 });
+        }
+        assertEquals(9, file.length());
+        file.remove(true);
+        try
+        {
+            file.length();
+        }
+        catch (final CoreException e)
+        {
+            assertTrue(e.getMessage().contains("Could not check length of path"));
+        }
+    }
+
+    @Test
+    public void testReadWrite() throws IOException
+    {
+        final File temp = this.temporaryFolder.newFile();
+        final HDFSFile file = new HDFSFile(temp.getPath());
+        final byte[] bytes = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
+        try (OutputStream outputStream = file.onWrite())
+        {
+            outputStream.write(bytes);
+        }
+        try (InputStream inputStream = file.onRead())
+        {
+            final byte[] readBytes = inputStream.readAllBytes();
+            assertArrayEquals(bytes, readBytes);
+        }
+    }
+
+    @Test
+    public void testReadWriteConcat() throws IOException
+    {
+        final File temp = this.temporaryFolder.newFile();
+        final HDFSFile file = new HDFSFile(temp.getPath());
+        file.setRetries(0);
+        final byte[] bytes = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
+        try (OutputStream outputStream = file.onWrite())
+        {
+            outputStream.write(bytes);
+        }
+        final byte[] bytes2 = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 10 };
+        assertFalse(file.isAppendToFile());
+        try (OutputStream outputStream = file.onWrite())
+        {
+            outputStream.write(bytes2);
+        }
+        try (InputStream inputStream = file.onRead())
+        {
+            final byte[] readBytes = inputStream.readAllBytes();
+            assertArrayEquals(bytes2, readBytes);
+        }
+
+        file.setAppendToFile(true);
+        assertTrue(file.isAppendToFile());
+        try (OutputStream outputStream = file.onWrite())
+        {
+            outputStream.write(bytes);
+        }
+        catch (final CoreException e)
+        {
+            Throwable throwable = e.getCause();
+            while (throwable instanceof CoreException)
+            {
+                throwable = throwable.getCause();
+            }
+            assertSame(IOException.class, throwable.getClass());
+            assertEquals("Not supported", throwable.getMessage());
+            // Appending is not currently supported, but when it is, the code outside this catch
+            // block will run
+            return;
+        }
+        try (InputStream inputStream = file.onRead())
+        {
+            final Collection<Byte> expected = new ArrayList<>();
+            for (final byte byt : bytes2)
+            {
+                expected.add(byt);
+            }
+            for (final byte byt : bytes)
+            {
+                expected.add(byt);
+            }
+            final Collection<Byte> readBytes = new ArrayList<>();
+            for (final byte byt : inputStream.readAllBytes())
+            {
+                readBytes.add(byt);
+            }
+            assertArrayEquals(expected.toArray(Byte[]::new), readBytes.toArray(Byte[]::new));
+        }
+        throw new AssertionError("Appending may be supported. Please modify this test.");
+    }
+
+    @Test
+    public void testRemove() throws IOException
+    {
+        final File temp = this.temporaryFolder.newFile("gzipped.gz");
+        final HDFSFile file = new HDFSFile(temp.getPath());
+        file.setRetries(0);
+        assertTrue(file.exists());
+        file.remove(false);
+        assertFalse(file.exists());
+        file.mkdirs(false);
+        final File temp2 = new File(temp, "random_file");
+        assertTrue(temp2.mkdir());
+        assertTrue(file.exists());
+        assertTrue(temp2.exists());
+        // This would be better with JUnit 5 assertThrows
+        try
+        {
+            file.remove(false);
+        }
+        catch (final CoreException e)
+        {
+            // Core exceptions should have an inner exception
+            assertTrue(
+                    e.getCause().getMessage().contains("Could not delete path in HDFS location"));
+            assertTrue(file.exists());
+            assertTrue(temp2.exists());
+        }
+        file.remove(true);
+        assertFalse(file.exists());
+        assertFalse(temp2.exists());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalkerTest.java
@@ -1,5 +1,8 @@
 package org.openstreetmap.atlas.generator.tools.streaming.resource;
 
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.FileSystems;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,17 +31,14 @@ public class HDFSWalkerTest
         final List<FileStatus> fileStatusList = new ArrayList<>();
         final List<String> debugStrings = new ArrayList<>();
         new HDFSWalker(depth).walk(new Path(directory.getPathString()))
-                .map(HDFSWalker.debug(debugStrings::add)).forEach(status ->
-                {
-                    fileStatusList.add(status);
-                });
+                .map(HDFSWalker.debug(debugStrings::add)).forEach(fileStatusList::add);
         return Tuple.createTuple(fileStatusList, debugStrings);
     }
 
     @Test
     public void testDirectoryListingWithMaxDepth()
     {
-        final File rootDirectory = File.temporaryFolder();
+        final File rootDirectory = File.temporaryFolder(FileSystems.getDefault());
         final File pathOne = rootDirectory.child("test-a");
         final File pathTwo = rootDirectory.child("test-b");
         pathOne.mkdirs();
@@ -65,7 +65,7 @@ public class HDFSWalkerTest
     @Test
     public void testDirectoryWithAFile()
     {
-        final File directory = File.temporaryFolder();
+        final File directory = File.temporaryFolder(FileSystems.getDefault());
         directory.child("test.tmp").writeAndClose("test file");
         final Tuple<List<FileStatus>, List<String>> results = HDFSWalkerTest.test(directory);
 
@@ -87,7 +87,7 @@ public class HDFSWalkerTest
     @Test
     public void testDirectoryWithAFileInsideAChildDirectory()
     {
-        final File directory = File.temporaryFolder();
+        final File directory = File.temporaryFolder(FileSystems.getDefault());
         directory.child("test.tmp").writeAndClose("test file");
         final File childDirectory = directory.child("child-directory");
         childDirectory.child("file-in-child-directory.tmp").writeAndClose("test child file");
@@ -100,11 +100,11 @@ public class HDFSWalkerTest
         // Verify debug strings
         Assert.assertFalse(results.getSecond().isEmpty());
         Assert.assertEquals(3, results.getSecond().size());
-        Assert.assertTrue(results.getSecond().contains(String.format("[D] file:%s/%s",
+        assertTrue(results.getSecond().contains(String.format("[D] file:%s/%s",
                 directory.getAbsolutePathString(), "child-directory")));
-        Assert.assertTrue(results.getSecond().contains(String.format("[F] file:%s/%s",
+        assertTrue(results.getSecond().contains(String.format("[F] file:%s/%s",
                 childDirectory.getAbsolutePathString(), "file-in-child-directory.tmp")));
-        Assert.assertTrue(results.getSecond().contains(
+        assertTrue(results.getSecond().contains(
                 String.format("[F] file:%s/%s", directory.getAbsolutePathString(), "test.tmp")));
 
         // Clean up
@@ -114,12 +114,12 @@ public class HDFSWalkerTest
     @Test
     public void testEmptyDirectory()
     {
-        final File emptyDirectory = File.temporaryFolder();
+        final File emptyDirectory = File.temporaryFolder(FileSystems.getDefault());
         final Tuple<List<FileStatus>, List<String>> results = HDFSWalkerTest.test(emptyDirectory);
 
         // Verify status and debug strings are empty
-        Assert.assertTrue(results.getFirst().isEmpty());
-        Assert.assertTrue(results.getSecond().isEmpty());
+        assertTrue(results.getFirst().isEmpty());
+        assertTrue(results.getSecond().isEmpty());
         emptyDirectory.deleteRecursively();
     }
 }


### PR DESCRIPTION
This fixes a resource leak, which will improve resource usage.

### Description:

Put `org.apache.hadoop.fs.FileSystem` creation into `try-with-resource` blocks. This ensures that the `FileSystem` is properly closed. There are also some fixes for sonar sprinkled in (mostly deduplication of strings).

### Potential Impact:

Major impact: Less resource utilization
No impact: No new exceptions are thrown (those that are thrown through the try-with-resources are caught and handled silently, to avoid breaking downstream users).

### Unit Test Approach:

N/A

### Test Results:

With https://github.com/osmlab/atlas-checks/pull/398, I was able to reduce the memory required to run the test check on NZL from 15 GB to 1GB. It may have been possible to run it with less memory (so < 1GB).

Notes:
* Additional modifications to `atlas-checks` was required in order to run the current `dev` branch of `atlas-generator`. Specifically, the resolution strategy for `jackson` had to be commented out (due to 54d1bd2b607f430379e18e2fee9166f6d803bf94 ).

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)


TODO list:
List of everything that uses `org.apache.hadoop.fs.FileSystem` (from imports):

* ~src/main/java/org/openstreetmap/atlas/generator/PbfLocator.java~ [DONE, implements AutoCloseable]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/AbstractFileOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasCountryStatisticsOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasFeatureChangeOutput.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasGeoJsonOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasProtoOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleAtlasStatisticsOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleFeatureChangeOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/MultipleLineDelimitedGeojsonOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/delta/AddedMultipleAtlasDeltaOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/delta/ChangedMultipleAtlasDeltaOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/delta/MultipleAtlasDeltaOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/persistence/delta/RemovedMultipleAtlasDeltaOutputFormat.java~ [N/A -- FileSystem passed into class]
* ~src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemCreator.java~ [N/A -- creates FileSystem objects for return]
* ~src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemHelper.java~ [DONE]
* ~src/main/java/org/openstreetmap/atlas/generator/tools/spark/DataLocator.java~ [DONE]
* ~src/main/java/org/openstreetmap/atlas/generator/tools/spark/SparkJob.java~ [DONE]
* ~src/main/java/org/openstreetmap/atlas/generator/tools/spark/input/SparkInput.java~ [DONE]
* ~src/main/java/org/openstreetmap/atlas/generator/tools/spark/rdd/ShardedAtlasRDDLoader.java~ [DONE]
* ~src/main/java/org/openstreetmap/atlas/generator/tools/spark/utilities/SparkFileHelper.java~ [DONE]
* src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
* ~src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSFile.java~ [DONE, implements AutoCloseable]
* ~src/main/java/org/openstreetmap/atlas/generator/tools/streaming/resource/HDFSWalker.java~ [mostly DONE, implements AutoCloseable, but I need to decide what to do with the exception, throw or catch, log, and suppress]
