### PR TITLE
Add directory support to listStatus

### DIFF
--- a/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/ResourceFileSystemTest.java
+++ b/src/test/java/org/openstreetmap/atlas/generator/tools/streaming/resource/ResourceFileSystemTest.java
@@ -1,7 +1,16 @@
 package org.openstreetmap.atlas.generator.tools.streaming.resource;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemCreator;
 import org.openstreetmap.atlas.generator.tools.streaming.ResourceFileSystem;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.StringResource;
@@ -11,6 +20,55 @@ import org.openstreetmap.atlas.streaming.resource.StringResource;
  */
 public class ResourceFileSystemTest
 {
+    @Test
+    public void listStatusTest()
+    {
+        ResourceFileSystem.clear();
+
+        final String simpleFilePath = ResourceFileSystem.SCHEME + "://test/path/file1";
+
+        final String longDirectoryPath = ResourceFileSystem.SCHEME
+                + "://test/path/with/lots/of/directories/file2";
+        final String intermediatePath = ResourceFileSystem.SCHEME + "://test/path/with/lots";
+        final String intermediatePathAndChild = ResourceFileSystem.SCHEME
+                + "://test/path/with/lots/of";
+
+        final String intermediatePath2 = ResourceFileSystem.SCHEME
+                + "://test/path/with/lots/of/directories";
+
+        ResourceFileSystem.addResource(longDirectoryPath, new StringResource("123"));
+        ResourceFileSystem.addResource(simpleFilePath, new StringResource("456"));
+
+        final FileSystem fileSystem = new FileSystemCreator().get(simpleFilePath,
+                FileSystemCreator.resourceFileSystemScheme());
+        try
+        {
+            List<FileStatus> fileStatuses = Arrays
+                    .asList(fileSystem.listStatus(new Path(simpleFilePath)));
+            Assert.assertEquals(1, fileStatuses.size());
+            Assert.assertEquals(simpleFilePath, fileStatuses.get(0).getPath().toString());
+            Assert.assertFalse(fileStatuses.get(0).isDirectory());
+
+            fileStatuses = Arrays.asList(
+                    fileSystem.listStatus(new Path(ResourceFileSystem.SCHEME + "://test/path/")));
+            Assert.assertEquals(2, fileStatuses.size());
+
+            fileStatuses = Arrays.asList(fileSystem.listStatus(new Path(intermediatePath)));
+            Assert.assertEquals(1, fileStatuses.size());
+            Assert.assertEquals(intermediatePathAndChild, fileStatuses.get(0).getPath().toString());
+            Assert.assertTrue(fileStatuses.get(0).isDirectory());
+
+            fileStatuses = Arrays.asList(fileSystem.listStatus(new Path(intermediatePath2)));
+            Assert.assertEquals(1, fileStatuses.size());
+            Assert.assertEquals(longDirectoryPath, fileStatuses.get(0).getPath().toString());
+            Assert.assertFalse(fileStatuses.get(0).isDirectory());
+        }
+        catch (final IOException e)
+        {
+            throw new CoreException("Unexpected exception in listStatusTest", e);
+        }
+    }
+
     @Test
     public void testDumpToDisk()
     {


### PR DESCRIPTION
### Description:
ListStatus doesn't handle directories right now, this PR adds support to return directories in cases where the prefix is a partial path.  

If the prefix is something like resource://test/path and the filepath is resource://test/path/to/a/file, a listStatus on resource://test/path will return the full filePath, not the next directory.  With this PR, we will now return resource://test/path/to and mark it as a directory.

### Potential Impact:
There will now be some preliminary support for directory handling in listStatus.  ResourceFileSystem is mainly used in test cases only, so limited impact.

### Unit Test Approach:
Add a unit test for listStatus in ResourceFileSystemTest
Make sure all other unitTests still work

### Test Results:
New unit Tests added!
All other unitTests still pass!

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
