### PR TITLE
AutoCloseable: Use autocloseable resources appropriately

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemCreator.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/filesystem/FileSystemCreator.java
@@ -43,6 +43,11 @@ public class FileSystemCreator
     {
         try
         {
+            final FileSystem fileSystem = FileSystem.get(new URI(path), configuration);
+            if (fileSystem != null)
+            {
+                return fileSystem;
+            }
             return FileSystem.newInstance(new URI(path), configuration);
         }
         catch (final Exception e)

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
@@ -54,15 +54,8 @@ public class PersistenceTools
         catch (final Exception e)
         {
             logger.error(e);
-            if (e instanceof RuntimeException)
-            {
-                throw (RuntimeException) e;
-            }
-            else
-            {
-                throw new CoreException("Could not close {}", e,
-                        SparkFileHelper.combine(input, BOUNDARIES_FILE));
-            }
+            throw new CoreException("Could not close {}",
+                    SparkFileHelper.combine(input, BOUNDARIES_FILE), e);
         }
     }
 

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/sharded/ShardedSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/sharded/ShardedSparkJob.java
@@ -10,6 +10,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.prep.PreparedPolygon;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
@@ -17,6 +18,7 @@ import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMapArchiver;
 import org.openstreetmap.atlas.geography.converters.jts.JtsPolygonConverter;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
+import org.openstreetmap.atlas.streaming.resource.ResourceCloseable;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.conversion.StringConverter;
@@ -88,8 +90,15 @@ public abstract class ShardedSparkJob extends SparkJob
         final Sharding sharding = AtlasSharding.forString(shardingType, configuration());
         final String countryShapes = (String) command.get(COUNTRY_SHAPES);
         logger.info("Reading country boundaries from {}", countryShapes);
-        final CountryBoundaryMap worldBoundaries = new CountryBoundaryMapArchiver()
-                .read(resource(countryShapes));
+        final CountryBoundaryMap worldBoundaries;
+        try (ResourceCloseable resource = resource(countryShapes))
+        {
+            worldBoundaries = new CountryBoundaryMapArchiver().read(resource);
+        }
+        catch (final Exception e)
+        {
+            throw new CoreException(e.getMessage());
+        }
         logger.info("Done Reading {} country boundaries from {}", worldBoundaries.size(),
                 countryShapes);
 

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/sharded/ShardedSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/sharded/ShardedSparkJob.java
@@ -97,7 +97,7 @@ public abstract class ShardedSparkJob extends SparkJob
         }
         catch (final Exception e)
         {
-            throw new CoreException(e.getMessage());
+            throw new CoreException("Could not read {}", countryShapes, e);
         }
         logger.info("Done Reading {} country boundaries from {}", worldBoundaries.size(),
                 countryShapes);

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/streaming/ResourceFileSystem.java
@@ -32,6 +32,7 @@ import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.streaming.resource.FileSuffix;
 import org.openstreetmap.atlas.streaming.resource.InputStreamResource;
 import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.streaming.resource.ResourceCloseable;
 import org.openstreetmap.atlas.streaming.resource.StringResource;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
 import org.openstreetmap.atlas.utilities.collections.StringList;
@@ -147,7 +148,7 @@ public class ResourceFileSystem extends FileSystem
         return getAtlas(path).orElseThrow(() -> new CoreException("{} not found.", path));
     }
 
-    public static Optional<Resource> getResource(final String path)
+    public static Optional<ResourceCloseable> getResource(final String path)
     {
         if (!path.startsWith(SCHEME + "://"))
         {
@@ -157,7 +158,7 @@ public class ResourceFileSystem extends FileSystem
         return Optional.ofNullable(SparkJob.resource(path, simpleconfiguration()));
     }
 
-    public static Resource getResourceOrElse(final String path)
+    public static ResourceCloseable getResourceOrElse(final String path)
     {
         return getResource(path).orElseThrow(() -> new CoreException("{} not found.", path));
     }


### PR DESCRIPTION
### Description:

Add Closeable Resources, for use when a Resource depends upon an AutoCloseable resource that must not be closed prior to the user finishing with the resource.

### Potential Impact:

This largely comes down to memory impact. In osmlab/atlas-generator#167, closing resources significantly freed up space and sped up processing. Unfortunately, during testing, a bug where resources were closed prior to reads was missed. This fixes that issue by creating resources that store the closeable resources internally, which can then be closed automatically when finished.

This may have been missed due to specifying a `-sharding` parameter and/or a less congested network.

### Test Results:

I've done several runs with an executor on a Raspberry Pi (also running a hadoop server) with two worker nodes on Mac computers.


This depends upon ~https://github.com/osmlab/atlas/pull/727~ (just merged, build won't pass until version bump)
