### PR TITLE
AQL Linting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ configurations
         exclude group: 'org.apache.hadoop'
         exclude group: 'org.apache.spark'
     }
+	aqlLintTask
 }
 
 dependencies
@@ -77,6 +78,8 @@ dependencies
     checkstyle packages.atlas_checkstyle
 
     shaded project.configurations.getByName('compile')
+
+	aqlLintTask packages.atlas
 }
 
 task shaded(type: Jar){

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -50,6 +50,14 @@ tasks.withType(Test) {
     reports.html.destination = file("${reporting.baseDir}/${name}")
 }
 
+task aqlLint(type: JavaExec, dependsOn: []) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = "org.openstreetmap.atlas.geography.atlas.dsl.engine.lint.gradle.LinterGradlePluginHelper"
+    args "${projectDir}", "org.openstreetmap.atlas.geography.atlas.dsl.engine.lint.lintlet.impl.InsecureWellFormednessLintlet"
+ }
+
+check.dependsOn(aqlLint)
+
 configurations
 {
     integrationTestCompile.extendsFrom testCompile


### PR DESCRIPTION
### Description:

This is a followup of https://github.com/osmlab/atlas-generator/pull/174 with respect to the [Atlas Query Language](https://github.com/osmlab/atlas/tree/6.4.0/src/main/groovy/org/openstreetmap/atlas/geography/atlas/dsl#atlas-query-language-aql) linting.

We add a build task which lints the AQL scripts included in the repo. 

### Potential Impact:

None

### Unit Test Approach:

None

### Test Results:

AQL lint task passes!

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
