### PR TITLE
Minor fix for pbf cut type

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
@@ -20,6 +20,7 @@ import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlas;
 import org.openstreetmap.atlas.geography.atlas.pbf.AtlasLoadingOption;
 import org.openstreetmap.atlas.geography.atlas.raw.creation.RawAtlasGenerator;
+import org.openstreetmap.atlas.geography.atlas.sub.AtlasCutType;
 import org.openstreetmap.atlas.geography.boundary.CountryBoundaryMap;
 import org.openstreetmap.atlas.geography.clipping.Clip.ClipType;
 import org.openstreetmap.atlas.geography.converters.jts.JtsMultiPolygonConverter;
@@ -135,6 +136,12 @@ public class PbfLoader implements AutoCloseable, Serializable
                         else
                         {
                             shardPbfSlice = rawAtlasGenerator.build();
+                            final Optional<Atlas> sub = shardPbfSlice.subAtlas(shard.bounds(),
+                                    AtlasCutType.SILK_CUT);
+                            if (sub.isPresent())
+                            {
+                                shardPbfSlice = rawAtlasGenerator.build();
+                            }
                         }
                     }
                     catch (final Exception e)


### PR DESCRIPTION
### Description:

This is a very minor improvement PR that just cuts atlas data generated to better fit PBF shard boundaries.

### Potential Impact:

Limited, if any.

### Unit Test Approach:

None, as it's really not expected to change anything for 99% of cases. Strictly decreases the occasional stray included line.

### Test Results:


------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
