### PR TITLE
Fix bug in PbfLoader

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/PbfLoader.java
@@ -140,7 +140,7 @@ public class PbfLoader implements AutoCloseable, Serializable
                                     AtlasCutType.SILK_CUT);
                             if (sub.isPresent())
                             {
-                                shardPbfSlice = rawAtlasGenerator.build();
+                                shardPbfSlice = sub.get();
                             }
                         }
                     }


### PR DESCRIPTION
### Description:

PbfLoader accidentally regenerates raw atlases instead of using the sub atlas optional 💀 

### Potential Impact:

Data quality should be better limited to shard bounds, atlas generation time will drop since we don't do it twice anymore

### Unit Test Approach:

No unit test since this actually behaved as expected with respect to data generation, it's just doing it twice unnecessarily.

### Test Results:


------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
