### PR TITLE
PersistenceTools: log4j -> slf4j logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
     id 'signing'
     id 'checkstyle'
     id 'jacoco'
-    id "com.diffplug.gradle.spotless" version "3.27.0"
-    id 'org.sonarqube' version '2.8'
+    id "com.diffplug.spotless" version "6.1.0"
+    id 'org.sonarqube' version '3.3'
     // id "io.codearte.nexus-staging" version "0.12.0"
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,11 +1,11 @@
 project.ext.versions = [
     checkstyle: '8.18',
-    jacoco: '0.8.3',
+    jacoco: '0.8.7',
     atlas: '7.0.2',
     spark: '3.0.1',
     snappy: '1.1.1.6',
     atlas_checkstyle: '5.6.9',
-    jline: '3.7.0'
+    jline: '3.21.0'
 ]
 
 project.ext.packages = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionSha256Sum=8b356fd8702d5ffa2e066ed0be45a023a779bba4dd1a68fd11bc2a6bdc981e8f
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
@@ -18,8 +18,6 @@ import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.ResourceCloseable;
 import org.openstreetmap.atlas.utilities.runtime.Command.Optionality;
 import org.openstreetmap.atlas.utilities.runtime.Command.Switch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author matthieun
@@ -38,7 +36,6 @@ public class PersistenceTools
 
     private static final Integer BUFFER_SIZE = 4 * 1024;
     private final Map<String, String> configurationMap;
-    private static final Logger logger = LoggerFactory.getLogger(PersistenceTools.class);
 
     public PersistenceTools(final Map<String, String> configurationMap)
     {
@@ -54,7 +51,6 @@ public class PersistenceTools
         }
         catch (final Exception e)
         {
-            logger.error("Could not close file", e);
             throw new CoreException("Could not close {}",
                     SparkFileHelper.combine(input, BOUNDARIES_FILE), e);
         }

--- a/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/tools/spark/persistence/PersistenceTools.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
-import org.apache.log4j.Logger;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
@@ -19,6 +18,8 @@ import org.openstreetmap.atlas.geography.sharding.Sharding;
 import org.openstreetmap.atlas.streaming.resource.ResourceCloseable;
 import org.openstreetmap.atlas.utilities.runtime.Command.Optionality;
 import org.openstreetmap.atlas.utilities.runtime.Command.Switch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author matthieun
@@ -37,7 +38,7 @@ public class PersistenceTools
 
     private static final Integer BUFFER_SIZE = 4 * 1024;
     private final Map<String, String> configurationMap;
-    private static final Logger logger = Logger.getLogger(PersistenceTools.class);
+    private static final Logger logger = LoggerFactory.getLogger(PersistenceTools.class);
 
     public PersistenceTools(final Map<String, String> configurationMap)
     {
@@ -53,7 +54,7 @@ public class PersistenceTools
         }
         catch (final Exception e)
         {
-            logger.error(e);
+            logger.error("Could not close file", e);
             throw new CoreException("Could not close {}",
                     SparkFileHelper.combine(input, BOUNDARIES_FILE), e);
         }


### PR DESCRIPTION
Move to slf4j logging throughout atlas generator.

I should have used slf4j initially, anyway.

There should be no impact on downstream projects.

See also
* https://github.com/osmlab/atlas-checks/pull/644
* https://github.com/osmlab/atlas/pull/780