### PR TITLE
Override Atlas metadata to guarantee shard name is correct

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/mutator/AtlasMutatorHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/mutator/AtlasMutatorHelper.java
@@ -603,7 +603,7 @@ public final class AtlasMutatorHelper implements Serializable
                             return new AtlasMetaData(metaData.getSize(), false,
                                     metaData.getCodeVersion().orElse(null),
                                     metaData.getDataVersion().orElse(null), country,
-                                    metaData.getShardName().orElse(null), metaData.getTags());
+                                    countryShard.getShard().getName(), metaData.getTags());
                         }
                     };
                     source.preemptiveLoad();


### PR DESCRIPTION
### Description:

Very small PR to address an occasional issue where sometimes shard data is improperly calculated due to dynamic atlas expansion. While a fix could hypothetically be made in DynamicAtlas, it actually makes more sense to include here-- the mutator driver itself is responsible for creating an expanded Atlas for a given shard (possibly extensively outside the shard bounds), at which point the "origin" shard is really only known to the mutator driver. Thus, having the mutator driver ensure the final Atlas is both trimmed to shard bounds *and* has the proper metadata is appropriate.

### Potential Impact:
Limited, outside of a piece of metadata being more consistent.

### Unit Test Approach:

### Test Results:

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
