### PR TITLE
Do not obscure exception stack trace in AtlasSharding

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasSharding.java
+++ b/src/main/java/org/openstreetmap/atlas/generator/sharding/AtlasSharding.java
@@ -71,7 +71,7 @@ public final class AtlasSharding
             }
             catch (final Exception e)
             {
-                throw new CoreException(e.getMessage());
+                throw new CoreException("Unable to parse sharding {}", sharding, e);
             }
         }
         throw new CoreException("Sharding type {} is not recognized.", split.get(0));


### PR DESCRIPTION
### Description:

`AtlasSharding` was obscuring the exception stack trace in the `dynamic` use case. This update is to have it print the underlying stack trace.

### Potential Impact:

None

### Unit Test Approach:

None

### Test Results:

Tested locally

------

In doubt: [Contributing Guidelines](https://github.com/osmlab/atlas/blob/dev/CONTRIBUTING.md)
